### PR TITLE
Update README: Add missing TLS_ACCEPT_TOS environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ For a simpler approach to publish local MCP servers over OAuth, consider [MCP Wa
 | `TLS_LISTEN`           | No       | Address to listen on for TLS                     | `:443`                                           |
 | `TLS_HOST`             | No       | Host name for automatic TLS certificate          | -                                                |
 | `TLS_DIRECTORY_URL`    | No       | ACME directory URL for TLS certificates          | `https://acme-v02.api.letsencrypt.org/directory` |
+| `TLS_ACCEPT_TOS`       | No       | Accept TLS terms of service                      | `false`                                          |
 | `DATA_PATH`            | No       | Data directory path                              | `./data`                                         |
 | `EXTERNAL_URL`         | No       | External URL for OAuth callbacks                 | `http://localhost`                               |
 | `PROXY_URL`            | No       | Target MCP server URL                            | `http://localhost:8080`                          |


### PR DESCRIPTION
## Summary
- Added the missing `TLS_ACCEPT_TOS` environment variable to the Environment Variables table in README.md

## Details
The `TLS_ACCEPT_TOS` environment variable was being used in the codebase (main.go:94) but was not documented in the README's Environment Variables section. This PR adds it to the table with the correct description and default value.