### PR TITLE
fix: update release workflow permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   release:
@@ -16,8 +17,6 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-          permission-contents: write
-          permission-pull-requests: write
       - uses: googleapis/release-please-action@v4
         with:
           token: ${{ steps.app.outputs.token }}


### PR DESCRIPTION
## Summary
- Add `issues: write` permission to support release-please functionality
- Remove redundant permission parameters from GitHub App action
- Simplify workflow by using top-level permissions instead of action-specific ones