### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+
+(Brief description of what this PR accomplishes)
+
+## Type of Change
+
+- [ ] **feat**: A new feature
+- [ ] **fix**: A bug fix
+- [ ] **docs**: Documentation only changes
+- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+- [ ] **refactor**: A code change that neither fixes a bug nor adds a feature
+- [ ] **perf**: A code change that improves performance
+- [ ] **test**: Adding missing tests or correcting existing tests
+- [ ] **build**: Changes that affect the build system or external dependencies
+- [ ] **ci**: Changes to our CI configuration files and scripts
+- [ ] **chore**: Other changes that don't modify src or test files
+- [ ] **revert**: Reverts a previous commit
+
+## Related Issues
+
+<!-- Example: Closes #123 or Fixes #456. Leave blank if no related issues. -->

--- a/README.md
+++ b/README.md
@@ -117,16 +117,6 @@ docker run --rm -p 8081:8081 --net=host \
 
 This project follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification for commit messages. This helps with automated versioning, changelog generation, and makes the commit history more readable.
 
-#### Format
-
-```
-<type>[optional scope]: <description>
-
-[optional body]
-
-[optional footer(s)]
-```
-
 #### Types
 
 - **feat**: A new feature


### PR DESCRIPTION
## Summary

- Add GitHub pull request template to standardize PR submissions
- Include conventional commit type checklist for consistency
- Remove duplicate conventional commits format section from README

## Type of Change

- [x] **docs**: Documentation only changes

## Related Issues

N/A - This is a documentation improvement to help contributors follow consistent PR practices.