### PR TITLE
ci: remove pull_request trigger from docker-build workflow

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
   release:
     types: [published]
 


### PR DESCRIPTION
## Summary

Remove the pull_request trigger from the docker-build workflow to prevent unnecessary builds on PRs. This optimization ensures Docker builds only run on main branch pushes and releases.

## Type of Change

- [x] **ci**: Changes to our CI configuration files and scripts

## Related Issues

<!-- No related issues -->