### PR TITLE
docs: add automatic TLS setup section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ If this project saves you time, please give it a star — it really helps visibi
 
 ## Quickstart
 
+### http
+
 ```
 docker run --rm -p 80:80 --net=host \
   -e EXTERNAL_URL=http://localhost \
@@ -22,6 +24,35 @@ docker run --rm -p 80:80 --net=host \
     "mcp": {
       "type": "http",
       "url": "http://localhost/mcp"
+    }
+  }
+}
+```
+
+### Automatic TLS
+
+For production use with a registered domain and external ports 80/443 accessible:
+
+```
+docker run --rm -p 80:80 -p 443:443 --net=host \
+  -e EXTERNAL_URL=https://{your-domain} \
+  -e PROXY_URL=http://localhost:8080 \
+  -e TLS_HOST={your-domain} \
+  -e TLS_ACCEPT_TOS=true \
+  -e PASSWORD=changeme \
+  -v ./data:/data \
+  ghcr.io/sigbit/mcp-auth-proxy:latest
+```
+
+This will automatically obtain and manage Let's Encrypt TLS certificates for your domain.
+
+.mcp.json
+```json
+{
+  "mcpServers": {
+    "mcp": {
+      "type": "http",
+      "url": "https://{your-domain}/mcp"
     }
   }
 }


### PR DESCRIPTION
## Summary

Add automatic TLS setup section to the quickstart guide with clear instructions for production deployment using Let's Encrypt certificates.

## Type of Change

- [ ] **feat**: A new feature
- [x] **fix**: A bug fix
- [x] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] **refactor**: A code change that neither fixes a bug nor adds a feature
- [ ] **perf**: A code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to our CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit

## Related Issues

<!-- Example: Closes #123 or Fixes #456. Leave blank if no related issues. -->