### PR TITLE
refactor: rename TLS_HOST_AUTO_DETECT to AUTO_TLS for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ For a simpler approach to publish local MCP servers over OAuth, consider [MCP Wa
 | ---------------------- | -------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
 | `LISTEN`               | No       | Server listen address                                                                                 | `:80`                                            |
 | `TLS_LISTEN`           | No       | Address to listen on for TLS                                                                          | `:443`                                           |
+| `AUTO_TLS`             | No       | Automatically setup TLS certificates from externalURL                                                 | `true`                                           |
 | `TLS_HOST`             | No       | Host name for automatic TLS certificate                                                               | -                                                |
-| `TLS_HOST_AUTO_DETECT` | No       | Automatically detect TLS host from externalURL                                                        | `true`                                           |
 | `TLS_DIRECTORY_URL`    | No       | ACME directory URL for TLS certificates                                                               | `https://acme-v02.api.letsencrypt.org/directory` |
 | `TLS_ACCEPT_TOS`       | No       | Accept TLS terms of service                                                                           | `false`                                          |
 | `DATA_PATH`            | No       | Data directory path                                                                                   | `./data`                                         |
@@ -210,3 +210,7 @@ Breaking changes should be indicated by a `!` after the type/scope:
 ```
 feat!: change authentication API to support multiple providers
 ```
+
+### PR Template
+
+- [./.github/pull_request_template.md](./.github/pull_request_template.md)

--- a/main.go
+++ b/main.go
@@ -28,8 +28,8 @@ func getEnvBoolWithDefault(key string, defaultValue bool) bool {
 func main() {
 	var listen string
 	var listenTLS string
+	var autoTLS bool
 	var tlsHost string
-	var tlsHostAutoDetect bool
 	var tlsDirectoryURL string
 	var tlsAcceptTOS bool
 	var dataPath string
@@ -76,8 +76,8 @@ func main() {
 			if err := mcpproxy.Run(
 				listen,
 				listenTLS,
+				autoTLS,
 				tlsHost,
-				tlsHostAutoDetect,
 				tlsDirectoryURL,
 				tlsAcceptTOS,
 				dataPath,
@@ -101,8 +101,8 @@ func main() {
 
 	rootCmd.Flags().StringVar(&listen, "listen", getEnvWithDefault("LISTEN", ":80"), "Address to listen on")
 	rootCmd.Flags().StringVar(&listenTLS, "listen-tls", getEnvWithDefault("TLS_LISTEN", ":443"), "Address to listen on for TLS")
+	rootCmd.Flags().BoolVar(&autoTLS, "auto-tls", getEnvBoolWithDefault("AUTO_TLS", true), "Automatically detect TLS host from externalURL")
 	rootCmd.Flags().StringVarP(&tlsHost, "tls-host", "H", getEnvWithDefault("TLS_HOST", ""), "Host name for TLS")
-	rootCmd.Flags().BoolVar(&tlsHostAutoDetect, "tls-host-auto-detect", getEnvBoolWithDefault("TLS_HOST_AUTO_DETECT", true), "Automatically detect TLS host from externalURL")
 	rootCmd.Flags().StringVar(&tlsDirectoryURL, "tls-directory-url", getEnvWithDefault("TLS_DIRECTORY_URL", "https://acme-v02.api.letsencrypt.org/directory"), "ACME directory URL for TLS certificates")
 	rootCmd.Flags().BoolVar(&tlsAcceptTOS, "tls-accept-tos", getEnvBoolWithDefault("TLS_ACCEPT_TOS", false), "Accept TLS terms of service")
 	rootCmd.Flags().StringVarP(&dataPath, "data", "d", getEnvWithDefault("DATA_PATH", "./data"), "Path to the data directory")

--- a/pkg/mcp-proxy/main.go
+++ b/pkg/mcp-proxy/main.go
@@ -36,8 +36,8 @@ var ServerShutdownTimeout = 5 * time.Second
 func Run(
 	listen string,
 	listenTLS string,
+	autoTLS bool,
 	tlsHost string,
-	tlsHostAutoDetect bool,
 	tlsDirectoryURL string,
 	tlsAcceptTOS bool,
 	dataPath string,
@@ -188,7 +188,7 @@ func Run(
 	proxyRouter.SetupRoutes(router)
 
 	var tlsHostDetected bool
-	if tlsHostAutoDetect &&
+	if autoTLS &&
 		tlsHost == "" &&
 		parsedExternalURL.Scheme == "https" &&
 		parsedExternalURL.Host != "localhost" {
@@ -204,7 +204,7 @@ func Run(
 	if tlsHost != "" {
 		if !tlsAcceptTOS {
 			if tlsHostDetected {
-				return errors.New("TLS host is auto-detected, but tlsAcceptTOS is not set to true. Please agree to the TOS or set tlsHostAutoDetect to false")
+				return errors.New("TLS host is auto-detected, but tlsAcceptTOS is not set to true. Please agree to the TOS or set autoTLS to false")
 			} else {
 				return errors.New("TLS is enabled, but tlsAcceptTOS is not set to true. Please explicitly agree to the TOS")
 			}


### PR DESCRIPTION
## Summary

Renamed `TLS_HOST_AUTO_DETECT` environment variable to `AUTO_TLS` for better clarity and consistency with the project's naming conventions.

## Type of Change

- [x] **refactor**: A code change that neither fixes a bug nor adds a feature

## Related Issues

<!-- Example: Closes #123 or Fixes #456. Leave blank if no related issues. -->