### PR TITLE
fix: improve KVS update method error handling

### DIFF
--- a/pkg/repository/kvs.go
+++ b/pkg/repository/kvs.go
@@ -68,9 +68,12 @@ func (r *kvsRepository) delete(ctx context.Context, key string) error {
 func (r *kvsRepository) update(ctx context.Context, key string, value any) error {
 	return r.db.Update(func(tx *bbolt.Tx) error {
 		bucket := tx.Bucket([]byte(r.bucketName))
+		if bucket.Get([]byte(key)) == nil {
+			return fosite.ErrNotFound
+		}
 		data, err := json.Marshal(value)
 		if err != nil {
-			return fosite.ErrNotFound
+			return fmt.Errorf("failed to marshal value: %w", err)
 		}
 		return bucket.Put([]byte(key), data)
 	})


### PR DESCRIPTION
## Summary

Improves error handling in the KVS repository update method by properly checking if a key exists before attempting to update it and providing better error messages for JSON marshalling failures.

## Type of Change

- [x] **fix**: A bug fix

## Related Issues

<!-- No related issues -->

## Changes Made

- Added existence check for key before update operation
- Return `fosite.ErrNotFound` when attempting to update non-existent key
- Improved error message for JSON marshalling failures from generic `ErrNotFound` to more descriptive error

## Testing

The changes improve error handling consistency and provide more accurate error responses when operations fail.