### PR TITLE
fix: remove oauth2.AccessTypeOffline from AuthCodeURL calls

### DIFF
--- a/pkg/auth/github.go
+++ b/pkg/auth/github.go
@@ -46,7 +46,7 @@ func (p *githubProvider) AuthURL() string {
 }
 
 func (p *githubProvider) AuthCodeURL(c *gin.Context, state string) (string, error) {
-	authURL := p.oauth2.AuthCodeURL(state, oauth2.AccessTypeOffline)
+	authURL := p.oauth2.AuthCodeURL(state)
 	return authURL, nil
 }
 

--- a/pkg/auth/google.go
+++ b/pkg/auth/google.go
@@ -42,7 +42,7 @@ func (p *googleProvider) RedirectURL() string {
 }
 
 func (p *googleProvider) AuthCodeURL(c *gin.Context, state string) (string, error) {
-	authURL := p.oauth2.AuthCodeURL(state, oauth2.AccessTypeOffline)
+	authURL := p.oauth2.AuthCodeURL(state)
 	return authURL, nil
 }
 


### PR DESCRIPTION
## Summary

Remove `oauth2.AccessTypeOffline` parameter from `AuthCodeURL` calls in both GitHub and Google OAuth providers. This parameter is not needed for the authorization code flow and may cause compatibility issues with some OAuth implementations.

## Type of Change

- [x] **fix**: A bug fix

## Related Issues

<!-- No related issues -->

## Changes Made

- Removed `oauth2.AccessTypeOffline` from GitHub provider's `AuthCodeURL` method
- Removed `oauth2.AccessTypeOffline` from Google provider's `AuthCodeURL` method

## Testing

- [ ] Existing tests pass
- [ ] Manual testing of OAuth flows completed