### PR TITLE
refactor: simplify provider management and add Type method

### DIFF
--- a/pkg/auth/github.go
+++ b/pkg/auth/github.go
@@ -37,6 +37,10 @@ func (p *githubProvider) Name() string {
 	return "GitHub"
 }
 
+func (p *githubProvider) Type() string {
+	return "github"
+}
+
 func (p *githubProvider) RedirectURL() string {
 	return GitHubCallbackEndpoint
 }

--- a/pkg/auth/google.go
+++ b/pkg/auth/google.go
@@ -37,6 +37,10 @@ func (p *googleProvider) Name() string {
 	return "Google"
 }
 
+func (p *googleProvider) Type() string {
+	return "google"
+}
+
 func (p *googleProvider) RedirectURL() string {
 	return GoogleCallbackEndpoint
 }

--- a/pkg/auth/interface.go
+++ b/pkg/auth/interface.go
@@ -10,6 +10,7 @@ import (
 
 type Provider interface {
 	Name() string
+	Type() string
 	RedirectURL() string
 	AuthURL() string
 	AuthCodeURL(c *gin.Context, state string) (string, error)

--- a/pkg/auth/mock.go
+++ b/pkg/auth/mock.go
@@ -143,3 +143,17 @@ func (mr *MockProviderMockRecorder) RedirectURL() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RedirectURL", reflect.TypeOf((*MockProvider)(nil).RedirectURL))
 }
+
+// Type mocks base method.
+func (m *MockProvider) Type() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Type")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Type indicates an expected call of Type.
+func (mr *MockProviderMockRecorder) Type() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockProvider)(nil).Type))
+}

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -63,6 +63,10 @@ func (p *oidcProvider) Name() string {
 	return p.providerName
 }
 
+func (p *oidcProvider) Type() string {
+	return "oidc"
+}
+
 func (p *oidcProvider) RedirectURL() string {
 	return OIDCCallbackEndpoint
 }

--- a/pkg/auth/templates/login.html
+++ b/pkg/auth/templates/login.html
@@ -117,19 +117,26 @@
         transform: translateY(-2px);
         box-shadow: 0 6px 16px rgba(0, 0, 0, 0.15);
       }
-      .Google {
+      .google {
         background-color: #4285f4;
         color: white;
       }
-      .Google:hover {
+      .google:hover {
         background-color: #357ae8;
       }
-      .GitHub {
+      .github {
         background-color: #333;
         color: white;
       }
-      .GitHub:hover {
+      .github:hover {
         background-color: #24292e;
+      }
+      .oidc {
+        background-color: #5c67f2;
+        color: white;
+      }
+      .oidc:hover {
+        background-color: #4e54d4;
       }
       .error-message {
         color: #e74c3c;
@@ -165,7 +172,7 @@
         <span>or</span>
       </div>
       {{end}} {{range .Providers}}
-      <a href="{{.URL}}" class="provider-button {{.Name }}">
+      <a href="{{.AuthURL}}" class="provider-button {{.Type}}">
         Login with {{.Name}}
       </a>
       {{end}}


### PR DESCRIPTION
## Summary

This PR refactors the provider management system to use a simpler slice-based approach instead of a map, and adds a new `Type()` method to the Provider interface for better CSS styling support.

## Type of Change

- [x] **refactor**: A code change that neither fixes a bug nor adds a feature

## Related Issues

<!-- Example: Closes #123 or Fixes #456. Leave blank if no related issues. -->

## Changes Made

- Changed providers from `map[string]Provider` to `[]Provider` for simpler management
- Added `Type() string` method to Provider interface to return CSS-friendly identifiers
- Updated all provider implementations (GitHub, Google, OIDC, Mock) to implement Type() method
- Simplified template data structure by removing intermediate `ProviderData` struct
- Updated login.html template to use `Type()` for CSS classes instead of `Name()`
- Added OIDC provider styling support in CSS

## Benefits

- Simpler provider management without the need for map-based lookups
- More consistent CSS class naming for provider buttons
- Better separation of concerns between display names and technical identifiers
- Cleaner template code with direct provider usage