### PR TITLE
docs: add Google site verification meta tag

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -102,6 +102,15 @@ const config: Config = {
       darkTheme: prismThemes.dracula,
     },
   } satisfies Preset.ThemeConfig,
+  headTags: [
+    {
+      tagName: "meta",
+      attributes: {
+        name: "google-site-verification",
+        content: "MgNfNOkNsGVgWZiK4YsMyCqj9KFbmD3T2wdkP17juvs",
+      },
+    },
+  ],
 };
 
 export default config;


### PR DESCRIPTION
## Summary

Add Google site verification meta tag to the Docusaurus configuration to enable Google Search Console integration for the documentation site.

## Type of Change

- [x] **docs**: Documentation only changes

## Related Issues

<!-- No related issues -->