### PR TITLE
docs: remove MCP Warp reference note

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,3 @@ That's it! Your HTTP endpoint is now available at `https://{your-domain}/mcp`.
 | Cursor            | ✅     |                                                  |
 
 - \*1: https://platform.openai.com/docs/mcp
-
-## Note
-
-For a simpler approach to publish local MCP servers over OAuth, consider [MCP Warp](https://github.com/sigbit/mcp-warp), which provides an OAuth Proxy + ngrok-like service. We highly recommend considering this option as well.


### PR DESCRIPTION
## Summary

Remove the note section at the bottom of README.md that references MCP Warp as a simpler alternative approach. This simplifies the documentation and removes potentially confusing alternative recommendations.

## Type of Change

- [x] **docs**: Documentation only changes

## Related Issues

<!-- No related issues -->