### PR TITLE
docs: remove compatibility note from verified clients section

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -336,9 +336,6 @@ function VerifiedClients() {
             </div>
           ))}
         </div>
-        <div className={styles.compatibilityNote}>
-          <p>All clients tested with stdio, SSE, and HTTP transports</p>
-        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary

Remove the compatibility note "All clients tested with stdio, SSE, and HTTP transports" from the verified clients section in the documentation homepage.

## Type of Change

- [x] **docs**: Documentation only changes

## Related Issues

<!-- Example: Closes #123 or Fixes #456. Leave blank if no related issues. -->