### PR TITLE
docs: add MCP Gateway comparison and reorganize documentation structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,25 @@
 
 📖 **For detailed usage, configuration, and examples, see the [Documentation](https://sigbit.github.io/mcp-auth-proxy/)**
 
+## Why not MCP Gateway?
+
+MCP Gateway: **A hub for operating multiple MCP servers together** (container isolation, catalog integration)  
+mcp-auth-proxy: **A lightweight proxy that adds authentication in front of any MCP server** (+ stdio→HTTP(S) conversion, optional)
+
+### When to choose `mcp-auth-proxy`
+
+- **You just want to add auth to one or a few MCPs** (enforce OAuth/OIDC/password with zero changes to the server)
+- **Container operations and catalog integration aren’t needed** (ideal for small setups, testing/PoC, or one-off exposure)
+
+### When to choose MCP Gateway
+
+- **Operating many MCPs at organizational scale** (provisioning, policy/permissions, audit, centralized logs)
+- **You want operations features** like container isolation and catalog integration
+
+_Note_: They are not mutually exclusive. You can **put `mcp-auth-proxy` in front of a Gateway's public endpoint to enforce authentication** if the Gateway itself doesn't handle it.
+
+**TL;DR:** Orchestrate many → Gateway / Expose safely & quickly → mcp-auth-proxy
+
 ## Quickstart
 
 > Domain binding & 80/443 must be accessible from outside.

--- a/docs/docs/client-integration.md
+++ b/docs/docs/client-integration.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 6
 ---
 
 # MCP Client Integration

--- a/docs/docs/comparison.md
+++ b/docs/docs/comparison.md
@@ -1,0 +1,22 @@
+---
+sidebar_position: 2
+---
+
+# Why not MCP Gateway?
+
+MCP Gateway: **A hub for operating multiple MCP servers together** (container isolation, catalog integration)  
+mcp-auth-proxy: **A lightweight proxy that adds authentication in front of any MCP server** (+ stdio→HTTP(S) conversion, optional)
+
+## When to choose `mcp-auth-proxy`
+
+- **You just want to add auth to one or a few MCPs** (enforce OAuth/OIDC/password with zero changes to the server)
+- **Container operations and catalog integration aren’t needed** (ideal for small setups, testing/PoC, or one-off exposure)
+
+## When to choose MCP Gateway
+
+- **Operating many MCPs at organizational scale** (provisioning, policy/permissions, audit, centralized logs)
+- **You want operations features** like container isolation and catalog integration
+
+_Note_: They are not mutually exclusive. You can **put `mcp-auth-proxy` in front of a Gateway's public endpoint to enforce authentication** if the Gateway itself doesn't handle it.
+
+**TL;DR:** Orchestrate many → Gateway / Expose safely & quickly → mcp-auth-proxy

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 7
 ---
 
 # Configuration Reference

--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 5
 ---
 
 # Configuration Examples

--- a/docs/docs/oauth-setup.md
+++ b/docs/docs/oauth-setup.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # OAuth Provider Setup

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # Quick Start


### PR DESCRIPTION
## Summary

Added a comprehensive comparison between mcp-auth-proxy and MCP Gateway to help users choose the right tool for their needs. Also reorganized the documentation sidebar structure for better navigation flow.

## Type of Change

- [x] **docs**: Documentation only changes

## Related Issues

<!-- No related issues -->