### PR TITLE
docs: move MCP Gateway comparison after Quickstart section

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,25 +15,6 @@
 
 📖 **For detailed usage, configuration, and examples, see the [Documentation](https://sigbit.github.io/mcp-auth-proxy/)**
 
-## Why not MCP Gateway?
-
-MCP Gateway: **A hub for operating multiple MCP servers together** (container isolation, catalog integration)  
-mcp-auth-proxy: **A lightweight proxy that adds authentication in front of any MCP server** (+ stdio→HTTP(S) conversion, optional)
-
-### When to choose `mcp-auth-proxy`
-
-- **You just want to add auth to one or a few MCPs** (enforce OAuth/OIDC/password with zero changes to the server)
-- **Container operations and catalog integration aren’t needed** (ideal for small setups, testing/PoC, or one-off exposure)
-
-### When to choose MCP Gateway
-
-- **Operating many MCPs at organizational scale** (provisioning, policy/permissions, audit, centralized logs)
-- **You want operations features** like container isolation and catalog integration
-
-_Note_: They are not mutually exclusive. You can **put `mcp-auth-proxy` in front of a Gateway's public endpoint to enforce authentication** if the Gateway itself doesn't handle it.
-
-**TL;DR:** Orchestrate many → Gateway / Expose safely & quickly → mcp-auth-proxy
-
 ## Quickstart
 
 > Domain binding & 80/443 must be accessible from outside.
@@ -54,6 +35,25 @@ That's it! Your HTTP endpoint is now available at `https://{your-domain}/mcp`.
 
 - stdio (when a command is specified): MCP endpoint is https://{your-domain}/mcp.
 - SSE/HTTP (when a URL is specified): MCP endpoint uses the backend’s original path (no conversion).
+
+## Why not MCP Gateway?
+
+MCP Gateway: **A hub for operating multiple MCP servers together** (container isolation, catalog integration)  
+mcp-auth-proxy: **A lightweight proxy that adds authentication in front of any MCP server** (+ stdio→HTTP(S) conversion, optional)
+
+### When to choose `mcp-auth-proxy`
+
+- **You just want to add auth to one or a few MCPs** (enforce OAuth/OIDC/password with zero changes to the server)
+- **Container operations and catalog integration aren’t needed** (ideal for small setups, testing/PoC, or one-off exposure)
+
+### When to choose MCP Gateway
+
+- **Operating many MCPs at organizational scale** (provisioning, policy/permissions, audit, centralized logs)
+- **You want operations features** like container isolation and catalog integration
+
+_Note_: They are not mutually exclusive. You can **put `mcp-auth-proxy` in front of a Gateway's public endpoint to enforce authentication** if the Gateway itself doesn't handle it.
+
+**TL;DR:** Orchestrate many → Gateway / Expose safely & quickly → mcp-auth-proxy
 
 ## Verified MCP Client
 


### PR DESCRIPTION
## Summary

Reorganizes the README structure by moving the "Why not MCP Gateway?" comparison section after the Quickstart section. This provides a better user experience by presenting the quickstart instructions first before diving into comparisons with other tools.

## Type of Change

- [x] **docs**: Documentation only changes

## Related Issues

<!-- No related issues -->