### PR TITLE
docs: clarify MCP Gateway comparison with improved messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,18 @@ That's it! Your HTTP endpoint is now available at `https://{your-domain}/mcp`.
 
 ## Why not MCP Gateway?
 
-MCP Gateway: **A hub for operating multiple MCP servers together** (container isolation, catalog integration)  
-mcp-auth-proxy: **A lightweight proxy that adds authentication in front of any MCP server** (+ stdio→HTTP(S) conversion, optional)
+mcp-auth-proxy: **A lightweight proxy that adds authentication to any MCP server** (optional stdio→HTTP(S) conversion)  
+MCP Gateway: **A hub to orchestrate multiple MCP servers** (aggregation, catalog integration)
 
 ### When to choose `mcp-auth-proxy`
 
-- **You just want to add auth to one or a few MCPs** (enforce OAuth/OIDC/password with zero changes to the server)
-- **Container operations and catalog integration aren’t needed** (ideal for small setups, testing/PoC, or one-off exposure)
+- **You just need to add auth to one or a few MCPs** (enforce OAuth/OIDC/password-only)
+- **Catalog integration isn’t needed** (no need for centralized catalog management)
 
 ### When to choose MCP Gateway
 
-- **Operating many MCPs at organizational scale** (provisioning, policy/permissions, audit, centralized logs)
-- **You want operations features** like container isolation and catalog integration
+- **You need to manage multiple MCPs centrally** (aggregation, policies/permissions, auditing, centralized logging)
+- **You want catalog integration**
 
 _Note_: They are not mutually exclusive. You can **put `mcp-auth-proxy` in front of a Gateway's public endpoint to enforce authentication** if the Gateway itself doesn't handle it.
 

--- a/docs/docs/comparison.md
+++ b/docs/docs/comparison.md
@@ -4,18 +4,18 @@ sidebar_position: 2
 
 # Why not MCP Gateway?
 
-MCP Gateway: **A hub for operating multiple MCP servers together** (container isolation, catalog integration)  
-mcp-auth-proxy: **A lightweight proxy that adds authentication in front of any MCP server** (+ stdio→HTTP(S) conversion, optional)
+mcp-auth-proxy: **A lightweight proxy that adds authentication to any MCP server** (optional stdio→HTTP(S) conversion)  
+MCP Gateway: **A hub to orchestrate multiple MCP servers** (aggregation, catalog integration)
 
 ## When to choose `mcp-auth-proxy`
 
-- **You just want to add auth to one or a few MCPs** (enforce OAuth/OIDC/password with zero changes to the server)
-- **Container operations and catalog integration aren’t needed** (ideal for small setups, testing/PoC, or one-off exposure)
+- **You just need to add auth to one or a few MCPs** (enforce OAuth/OIDC/password-only)
+- **Catalog integration isn’t needed** (no need for centralized catalog management)
 
 ## When to choose MCP Gateway
 
-- **Operating many MCPs at organizational scale** (provisioning, policy/permissions, audit, centralized logs)
-- **You want operations features** like container isolation and catalog integration
+- **You need to manage multiple MCPs centrally** (aggregation, policies/permissions, auditing, centralized logging)
+- **You want catalog integration**
 
 _Note_: They are not mutually exclusive. You can **put `mcp-auth-proxy` in front of a Gateway's public endpoint to enforce authentication** if the Gateway itself doesn't handle it.
 


### PR DESCRIPTION
## Summary

This PR improves the clarity and messaging of the MCP Gateway comparison section in both the README and documentation. The changes make the comparison more actionable and better highlight the distinct value propositions of each tool.

## Type of Change

- [x] **docs**: Documentation only changes

## Changes Made

- Reordered comparison to lead with mcp-auth-proxy's value proposition
- Simplified language and focused on core differentiators  
- Made use cases more specific and actionable
- Improved parallel structure between sections for better readability

## Related Issues

<!-- No related issues -->