### PR TITLE
docs: improve catalog integration messaging for clearer differentiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ MCP Gateway: **A hub to orchestrate multiple MCP servers** (aggregation, catalog
 ### When to choose `mcp-auth-proxy`
 
 - **You just need to add auth to one or a few MCPs** (enforce OAuth/OIDC/password-only)
-- **Catalog integration isn’t needed** (no need for centralized catalog management)
+- **Catalog integration and aggregation aren’t needed** (either self-hosted or independently managed MCP.)
 
 ### When to choose MCP Gateway
 
 - **You need to manage multiple MCPs centrally** (aggregation, policies/permissions, auditing, centralized logging)
-- **You want catalog integration**
+- **You want catalog integration and aggregation**
 
 _Note_: They are not mutually exclusive. You can **put `mcp-auth-proxy` in front of a Gateway's public endpoint to enforce authentication** if the Gateway itself doesn't handle it.
 

--- a/docs/docs/comparison.md
+++ b/docs/docs/comparison.md
@@ -10,12 +10,12 @@ MCP Gateway: **A hub to orchestrate multiple MCP servers** (aggregation, catalog
 ## When to choose `mcp-auth-proxy`
 
 - **You just need to add auth to one or a few MCPs** (enforce OAuth/OIDC/password-only)
-- **Catalog integration isn’t needed** (no need for centralized catalog management)
+- **Catalog integration and aggregation aren’t needed** (either self-hosted or independently managed MCP.)
 
 ## When to choose MCP Gateway
 
 - **You need to manage multiple MCPs centrally** (aggregation, policies/permissions, auditing, centralized logging)
-- **You want catalog integration**
+- **You want catalog integration and aggregation**
 
 _Note_: They are not mutually exclusive. You can **put `mcp-auth-proxy` in front of a Gateway's public endpoint to enforce authentication** if the Gateway itself doesn't handle it.
 


### PR DESCRIPTION
## Summary

Improve the messaging around catalog integration and aggregation in both README.md and comparison documentation to help users better understand when to choose mcp-auth-proxy vs MCP Gateway.

## Type of Change

- [x] **docs**: Documentation only changes

## Related Issues

<!-- No related issues -->