### PR TITLE
docs: improve comparison text clarity with concrete examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ MCP Gateway: **A hub to orchestrate multiple MCP servers** (aggregation, catalog
 ### When to choose `mcp-auth-proxy`
 
 - **You just need to add auth to one or a few MCPs** (enforce OAuth/OIDC/password-only)
-- **Catalog integration and aggregation aren’t needed** (either self-hosted or independently managed MCP.)
+- **Catalog integration and aggregation aren’t needed** (e.g., self-hosted or independently managed MCP deployments)
 
 ### When to choose MCP Gateway
 

--- a/docs/docs/comparison.md
+++ b/docs/docs/comparison.md
@@ -10,7 +10,7 @@ MCP Gateway: **A hub to orchestrate multiple MCP servers** (aggregation, catalog
 ## When to choose `mcp-auth-proxy`
 
 - **You just need to add auth to one or a few MCPs** (enforce OAuth/OIDC/password-only)
-- **Catalog integration and aggregation aren’t needed** (either self-hosted or independently managed MCP.)
+- **Catalog integration and aggregation aren’t needed** (e.g., self-hosted or independently managed MCP deployments)
 
 ## When to choose MCP Gateway
 


### PR DESCRIPTION
## Summary

Improves the clarity of comparison text in both README.md and docs/comparison.md by replacing vague parenthetical language with concrete examples. The change replaces "(either self-hosted or independently managed MCP.)" with "(e.g., self-hosted or independently managed MCP deployments)" to better illustrate when catalog integration and aggregation aren't needed.

## Type of Change

- [x] **docs**: Documentation only changes

## Related Issues

<!-- Example: Closes #123 or Fixes #456. Leave blank if no related issues. -->