### PR TITLE
fix: improve Docker image tagging strategy for releases

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -40,9 +40,11 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
-            type=ref,event=pr,prefix=pr-
             type=ref,event=tag
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' && github.event.action == 'published' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' && github.event.action == 'published' }}
+            type=semver,pattern={{major}},enable=${{ github.event_name == 'release' && github.event.action == 'published' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && github.event.action == 'published' }}
 
       - name: Build and push Docker image
         id: build-and-push


### PR DESCRIPTION
## Summary

This PR improves the Docker image tagging strategy to better align with release workflows and reduce unnecessary image builds. The changes ensure that semantic version tags and the 'latest' tag are only applied during official releases, while removing PR-specific tagging that was creating redundant images.

## Type of Change

- [x] **fix**: A bug fix
- [ ] **feat**: A new feature
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] **refactor**: A code change that neither fixes a bug nor adds a feature
- [ ] **perf**: A code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [x] **ci**: Changes to our CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit

## Changes Made

- Removed PR-specific tagging (`type=ref,event=pr,prefix=pr-`) to avoid unnecessary image builds on every PR
- Added semantic versioning tags that only trigger on release events:
  - `{{version}}` (e.g., `1.2.3`)
  - `{{major}}.{{minor}}` (e.g., `1.2`)
  - `{{major}}` (e.g., `1`)
- Restricted `latest` tag to only apply when releases are published instead of on every main branch push
- All version-related tags now only activate when `github.event_name == 'release'` and `github.event.action == 'published'`

## Benefits

- Reduces Docker registry storage by eliminating redundant PR images
- Provides proper semantic versioning for releases
- Ensures `latest` tag truly represents the latest stable release
- Maintains branch-based tagging for development builds

## Related Issues

<!-- Example: Closes #123 or Fixes #456. Leave blank if no related issues. -->