### PR TITLE
docs: update configuration documentation with latest options

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -34,19 +34,21 @@ Complete reference for all MCP Auth Proxy configuration options.
 
 #### Google OAuth
 
-| Option                   | Environment Variable   | Default | Description                                           |
-| ------------------------ | ---------------------- | ------- | ----------------------------------------------------- |
-| `--google-client-id`     | `GOOGLE_CLIENT_ID`     | -       | Google OAuth client ID                                |
-| `--google-client-secret` | `GOOGLE_CLIENT_SECRET` | -       | Google OAuth client secret                            |
-| `--google-allowed-users` | `GOOGLE_ALLOWED_USERS` | -       | Comma-separated list of allowed Google users (emails) |
+| Option                        | Environment Variable        | Default | Description                                           |
+| ----------------------------- | --------------------------- | ------- | ----------------------------------------------------- |
+| `--google-client-id`          | `GOOGLE_CLIENT_ID`          | -       | Google OAuth client ID                                |
+| `--google-client-secret`      | `GOOGLE_CLIENT_SECRET`      | -       | Google OAuth client secret                            |
+| `--google-allowed-users`      | `GOOGLE_ALLOWED_USERS`      | -       | Comma-separated list of allowed Google users (emails) |
+| `--google-allowed-workspaces` | `GOOGLE_ALLOWED_WORKSPACES` | -       | Comma-separated list of allowed Google workspaces     |
 
 #### GitHub OAuth
 
-| Option                   | Environment Variable   | Default | Description                                              |
-| ------------------------ | ---------------------- | ------- | -------------------------------------------------------- |
-| `--github-client-id`     | `GITHUB_CLIENT_ID`     | -       | GitHub OAuth client ID                                   |
-| `--github-client-secret` | `GITHUB_CLIENT_SECRET` | -       | GitHub OAuth client secret                               |
-| `--github-allowed-users` | `GITHUB_ALLOWED_USERS` | -       | Comma-separated list of allowed GitHub users (usernames) |
+| Option                   | Environment Variable   | Default | Description                                                                                                                      |
+| ------------------------ | ---------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `--github-client-id`     | `GITHUB_CLIENT_ID`     | -       | GitHub OAuth client ID                                                                                                           |
+| `--github-client-secret` | `GITHUB_CLIENT_SECRET` | -       | GitHub OAuth client secret                                                                                                       |
+| `--github-allowed-users` | `GITHUB_ALLOWED_USERS` | -       | Comma-separated list of allowed GitHub users (usernames)                                                                         |
+| `--github-allowed-orgs`  | `GITHUB_ALLOWED_ORGS`  | -       | Comma-separated list of allowed GitHub organizations. You can also restrict access to specific teams using the format `Org:Team` |
 
 #### Generic OIDC
 
@@ -74,5 +76,6 @@ Complete reference for all MCP Auth Proxy configuration options.
 | ---------------------- | -------------------- | ------- | ----------------------------------------------------------------------------------------------------- |
 | `--proxy-bearer-token` | `PROXY_BEARER_TOKEN` | -       | Bearer token to add to Authorization header when proxying requests                                    |
 | `--proxy-headers`      | `PROXY_HEADERS`      | -       | Comma-separated list of headers to add when proxying requests (format: Header1:Value1,Header2:Value2) |
+| `--trusted-proxies`    | `TRUSTED_PROXIES`    | -       | Comma-separated list of trusted proxies (IP addresses or CIDR ranges)                                 |
 
 For practical configuration examples including environment variables, Docker Compose, and Kubernetes deployments, see the [Configuration Examples](./examples.md) page.

--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -37,6 +37,12 @@ services:
       - GOOGLE_CLIENT_ID=your-google-client-id
       - GOOGLE_CLIENT_SECRET=your-google-client-secret
       - GOOGLE_ALLOWED_USERS=user1@example.com,user2@example.com
+      - GOOGLE_ALLOWED_WORKSPACES=workspace1.com,workspace2.com
+      - GITHUB_CLIENT_ID=your-github-client-id
+      - GITHUB_CLIENT_SECRET=your-github-client-secret
+      - GITHUB_ALLOWED_USERS=username1,username2
+      - GITHUB_ALLOWED_ORGS=org1,org2:team1
+      - TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
     volumes:
       - ./data:/data
     command: ["npx", "-y", "@modelcontextprotocol/server-filesystem", "./"]

--- a/docs/docs/oauth-setup.md
+++ b/docs/docs/oauth-setup.md
@@ -30,6 +30,7 @@ Configure OAuth providers to enable secure authentication for your MCP server.
 
 ### 3. Configure MCP Auth Proxy
 
+#### Allow specific users:
 ```bash
 ./mcp-auth-proxy \
   --external-url https://{your-domain} \
@@ -37,6 +38,17 @@ Configure OAuth providers to enable secure authentication for your MCP server.
   --google-client-id "your-google-client-id" \
   --google-client-secret "your-google-client-secret" \
   --google-allowed-users "user1@example.com,user2@example.com" \
+  -- your-mcp-command
+```
+
+#### Allow entire Google Workspaces:
+```bash
+./mcp-auth-proxy \
+  --external-url https://{your-domain} \
+  --tls-accept-tos \
+  --google-client-id "your-google-client-id" \
+  --google-client-secret "your-google-client-secret" \
+  --google-allowed-workspaces "workspace1.com,workspace2.com" \
   -- your-mcp-command
 ```
 
@@ -60,6 +72,7 @@ Configure OAuth providers to enable secure authentication for your MCP server.
   --github-client-id "your-github-client-id" \
   --github-client-secret "your-github-client-secret" \
   --github-allowed-users "username1,username2" \
+  --github-allowed-orgs "org1,org2:team1" \
   -- your-mcp-command
 ```
 
@@ -141,10 +154,12 @@ All OAuth settings can be configured using environment variables:
 export GOOGLE_CLIENT_ID="your-google-client-id"
 export GOOGLE_CLIENT_SECRET="your-google-client-secret"
 export GOOGLE_ALLOWED_USERS="user1@example.com,user2@example.com"
+export GOOGLE_ALLOWED_WORKSPACES="workspace1.com,workspace2.com"
 
 export GITHUB_CLIENT_ID="your-github-client-id"
 export GITHUB_CLIENT_SECRET="your-github-client-secret"
 export GITHUB_ALLOWED_USERS="username1,username2"
+export GITHUB_ALLOWED_ORGS="org1,org2:team1"
 
 export OIDC_CONFIGURATION_URL="https://provider.com/.well-known/openid-configuration"
 export OIDC_CLIENT_ID="your-oidc-client-id"


### PR DESCRIPTION
## Summary
- Updates documentation to reflect the latest configuration options added in recent releases
- Adds documentation for Google Workspace and GitHub organization/team access controls
- Includes trusted proxy configuration for reverse proxy environments

## Changes
- **Configuration Reference**: Added `--google-allowed-workspaces`, `--github-allowed-orgs`, and `--trusted-proxies` options
- **OAuth Setup Guide**: Enhanced with examples for workspace and organization-level access control
- **Docker Compose Examples**: Updated environment variables to showcase new options

## Test plan
- [x] Verified all new options are documented correctly
- [x] Checked examples match the actual command-line interface
- [x] Ensured consistent formatting across all documentation files