### PR TITLE
fix: replace context.Done() with Wait() in backend tests

### DIFF
--- a/pkg/backend/proxy_test.go
+++ b/pkg/backend/proxy_test.go
@@ -85,7 +85,7 @@ func TestProxyBackendRun(t *testing.T) {
 
 	checkCh := make(chan struct{})
 	go func() {
-		<-ctx.Done()
+		pb.Wait()
 		close(checkCh)
 	}()
 

--- a/pkg/backend/transparent_test.go
+++ b/pkg/backend/transparent_test.go
@@ -114,7 +114,7 @@ func TestTransparentBackendRun(t *testing.T) {
 
 	checkCh := make(chan struct{})
 	go func() {
-		<-ctx.Done()
+		be.Wait()
 		close(checkCh)
 	}()
 


### PR DESCRIPTION
## Summary

Replace `ctx.Done()` with proper `Wait()` method calls in proxy and transparent backend tests to ensure proper cleanup and synchronization.

## Type of Change

- [x] **fix**: A bug fix

## Related Issues

<!-- Leave blank if no related issues -->