### PR TITLE
feat: support glob patterns for OIDC allowed users

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 
 - **Drop-in OAuth 2.1/OIDC gateway for MCP servers — put it in front, no code changes.**
 - **Your IdP, your choice**: Google, GitHub, or any OIDC provider — e.g. Okta, Auth0, Azure AD, Keycloak — plus optional password.
-- **Publish local MCP servers safely**: Supports all stdio, SSE, and HTTP transports. For stdio, traffic is converted to `/mcp`. For SSE/HTTP, it’s proxied as-is. Of course, with authentication.
+- **Flexible user matching**: Support exact matching and glob patterns for user authorization (e.g., `*@company.com`)
+- **Publish local MCP servers safely**: Supports all stdio, SSE, and HTTP transports. For stdio, traffic is converted to `/mcp`. For SSE/HTTP, it's proxied as-is. Of course, with authentication.
 - **Verified across major MCP clients**: Claude, Claude Code, ChatGPT, GitHub Copilot, Cursor, etc. — the proxy smooths client-specific quirks for consistent auth.
 
 ---

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -52,15 +52,37 @@ Complete reference for all MCP Auth Proxy configuration options.
 
 #### Generic OIDC
 
-| Option                     | Environment Variable     | Default                | Description                                                 |
-| -------------------------- | ------------------------ | ---------------------- | ----------------------------------------------------------- |
-| `--oidc-configuration-url` | `OIDC_CONFIGURATION_URL` | -                      | OIDC configuration URL                                      |
-| `--oidc-client-id`         | `OIDC_CLIENT_ID`         | -                      | OIDC client ID                                              |
-| `--oidc-client-secret`     | `OIDC_CLIENT_SECRET`     | -                      | OIDC client secret                                          |
-| `--oidc-allowed-users`     | `OIDC_ALLOWED_USERS`     | -                      | Comma-separated list of allowed OIDC users                  |
-| `--oidc-provider-name`     | `OIDC_PROVIDER_NAME`     | `OIDC`                 | Display name for OIDC provider                              |
-| `--oidc-scopes`            | `OIDC_SCOPES`            | `openid,profile,email` | Comma-separated list of OIDC scopes                         |
-| `--oidc-user-id-field`     | `OIDC_USER_ID_FIELD`     | `/email`               | JSON pointer to user ID field in userinfo endpoint response |
+| Option                      | Environment Variable      | Default                | Description                                                  |
+| --------------------------- | ------------------------- | ---------------------- | ------------------------------------------------------------ |
+| `--oidc-configuration-url`  | `OIDC_CONFIGURATION_URL`  | -                      | OIDC configuration URL                                       |
+| `--oidc-client-id`          | `OIDC_CLIENT_ID`          | -                      | OIDC client ID                                               |
+| `--oidc-client-secret`      | `OIDC_CLIENT_SECRET`      | -                      | OIDC client secret                                           |
+| `--oidc-allowed-users`      | `OIDC_ALLOWED_USERS`      | -                      | Comma-separated list of allowed OIDC users (exact match)     |
+| `--oidc-allowed-users-glob` | `OIDC_ALLOWED_USERS_GLOB` | -                      | Comma-separated list of glob patterns for allowed OIDC users |
+| `--oidc-provider-name`      | `OIDC_PROVIDER_NAME`      | `OIDC`                 | Display name for OIDC provider                               |
+| `--oidc-scopes`             | `OIDC_SCOPES`             | `openid,profile,email` | Comma-separated list of OIDC scopes                          |
+| `--oidc-user-id-field`      | `OIDC_USER_ID_FIELD`      | `/email`               | JSON pointer to user ID field in userinfo endpoint response  |
+
+##### OIDC User Matching
+
+You can use both exact matching and glob patterns for OIDC user authorization:
+
+- **Exact matching** (`--oidc-allowed-users`): Users must match exactly
+- **Glob patterns** (`--oidc-allowed-users-glob`): Users are matched against [glob patterns](https://github.com/gobwas/glob)
+
+**Examples:**
+
+```bash
+# Exact matching
+--oidc-allowed-users "user1@example.com,admin@company.org"
+
+# Glob patterns - allow all users from example.com
+--oidc-allowed-users-glob "*@example.com"
+
+# Combined exact and glob matching
+--oidc-allowed-users "specific@user.com" \
+--oidc-allowed-users-glob "*@example.com"
+```
 
 ### Server Options
 

--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -42,6 +42,11 @@ services:
       - GITHUB_CLIENT_SECRET=your-github-client-secret
       - GITHUB_ALLOWED_USERS=username1,username2
       - GITHUB_ALLOWED_ORGS=org1,org2:team1
+      - OIDC_CONFIGURATION_URL=https://your-oidc-provider/.well-known/openid_configuration
+      - OIDC_CLIENT_ID=your-oidc-client-id
+      - OIDC_CLIENT_SECRET=your-oidc-client-secret
+      - OIDC_ALLOWED_USERS=specific@user.com
+      - OIDC_ALLOWED_USERS_GLOB=*@example.com
       - TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
     volumes:
       - ./data:/data

--- a/docs/docs/oauth-setup.md
+++ b/docs/docs/oauth-setup.md
@@ -99,6 +99,8 @@ Configure OAuth providers to enable secure authentication for your MCP server.
 
 ### 2. Configure MCP Auth Proxy
 
+#### Exact user matching:
+
 ```bash
 ./mcp-auth-proxy \
   --external-url https://{your-domain} \
@@ -107,6 +109,19 @@ Configure OAuth providers to enable secure authentication for your MCP server.
   --oidc-client-id "your-oidc-client-id" \
   --oidc-client-secret "your-oidc-client-secret" \
   --oidc-allowed-users "user1@example.com,user2@example.com" \
+  -- your-mcp-command
+```
+
+#### Glob pattern matching:
+
+```bash
+./mcp-auth-proxy \
+  --external-url https://{your-domain} \
+  --tls-accept-tos \
+  --oidc-configuration-url "https://your-provider.com/.well-known/openid-configuration" \
+  --oidc-client-id "your-oidc-client-id" \
+  --oidc-client-secret "your-oidc-client-secret" \
+  --oidc-allowed-users-glob "*@example.com" \
   -- your-mcp-command
 ```
 
@@ -167,6 +182,7 @@ export OIDC_CONFIGURATION_URL="https://provider.com/.well-known/openid-configura
 export OIDC_CLIENT_ID="your-oidc-client-id"
 export OIDC_CLIENT_SECRET="your-oidc-client-secret"
 export OIDC_ALLOWED_USERS="user1@example.com,user2@example.com"
+export OIDC_ALLOWED_USERS_GLOB="*@example.com"
 
 ./mcp-auth-proxy --external-url https://{your-domain} --tls-accept-tos -- your-mcp-command
 ```

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/gin-contrib/sessions v1.0.4
 	github.com/gin-contrib/zap v1.1.5
 	github.com/gin-gonic/gin v1.10.1
+	github.com/gobwas/glob v0.2.3
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/mark3labs/mcp-go v0.37.0
 	github.com/mattn/go-jsonpointer v0.0.1
@@ -46,7 +47,6 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.26.0 // indirect
 	github.com/gobuffalo/pop/v6 v6.1.1 // indirect
-	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/mock v1.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.26.0 // indirect
 	github.com/gobuffalo/pop/v6 v6.1.1 // indirect
+	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/mock v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/gobuffalo/pop/v6 v6.1.1 h1:eUDBaZcb0gYrmFnKwpuTEUA7t5ZHqNfvS4POqJYXDZ
 github.com/gobuffalo/pop/v6 v6.1.1/go.mod h1:1n7jAmI1i7fxuXPZjZb0VBPQDbksRtCoFnrDV5IsvaI=
 github.com/gobuffalo/tags/v3 v3.1.4/go.mod h1:ArRNo3ErlHO8BtdA0REaZxijuWnWzF6PUXngmMXd2I0=
 github.com/gobuffalo/validate/v3 v3.3.3/go.mod h1:YC7FsbJ/9hW/VjQdmXPvFqvRis4vrRYFxr69WiNZw6g=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,219 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitWithEscapes(t *testing.T) {
+	testCases := []struct {
+		name      string
+		input     string
+		delimiter string
+		expected  []string
+	}{
+		{
+			name:      "simple comma split",
+			input:     "a,b,c",
+			delimiter: ",",
+			expected:  []string{"a", "b", "c"},
+		},
+		{
+			name:      "escaped comma",
+			input:     "a,b\\,c,d",
+			delimiter: ",",
+			expected:  []string{"a", "b,c", "d"},
+		},
+		{
+			name:      "email with escaped comma",
+			input:     "user@domain.com\\,backup,*@example.org",
+			delimiter: ",",
+			expected:  []string{"user@domain.com,backup", "*@example.org"},
+		},
+		{
+			name:      "glob pattern with escaped comma",
+			input:     "admin.*@company\\,inc.*,*@example.com",
+			delimiter: ",",
+			expected:  []string{"admin.*@company,inc.*", "*@example.com"},
+		},
+		{
+			name:      "empty string",
+			input:     "",
+			delimiter: ",",
+			expected:  []string{},
+		},
+		{
+			name:      "single item",
+			input:     "single",
+			delimiter: ",",
+			expected:  []string{"single"},
+		},
+		{
+			name:      "no escapes needed",
+			input:     "user1@example.com,user2@test.org",
+			delimiter: ",",
+			expected:  []string{"user1@example.com", "user2@test.org"},
+		},
+		{
+			name:      "multiple escaped commas",
+			input:     "a\\,b\\,c,d,e\\,f",
+			delimiter: ",",
+			expected:  []string{"a,b,c", "d", "e,f"},
+		},
+		{
+			name:      "whitespace trimming",
+			input:     "a , b\\,c , d",
+			delimiter: ",",
+			expected:  []string{"a", "b,c", "d"},
+		},
+		{
+			name:      "different delimiter",
+			input:     "a;b\\;c;d",
+			delimiter: ";",
+			expected:  []string{"a", "b;c", "d"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := splitWithEscapes(tc.input, tc.delimiter)
+
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("Expected %v, got %v", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestGetEnvWithDefault(t *testing.T) {
+	testCases := []struct {
+		name     string
+		key      string
+		def      string
+		expected string
+		setEnv   bool
+		envValue string
+	}{
+		{
+			name:     "env var not set",
+			key:      "TEST_KEY_NOT_SET",
+			def:      "default_value",
+			expected: "default_value",
+			setEnv:   false,
+		},
+		{
+			name:     "env var set",
+			key:      "TEST_KEY_SET",
+			def:      "default_value",
+			expected: "env_value",
+			setEnv:   true,
+			envValue: "env_value",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup
+			if tc.setEnv {
+				t.Setenv(tc.key, tc.envValue)
+			}
+
+			// Test
+			result := getEnvWithDefault(tc.key, tc.def)
+
+			if result != tc.expected {
+				t.Errorf("Expected %s, got %s", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestGetEnvBoolWithDefault(t *testing.T) {
+	testCases := []struct {
+		name     string
+		key      string
+		def      bool
+		expected bool
+		setEnv   bool
+		envValue string
+	}{
+		{
+			name:     "env var not set - default false",
+			key:      "TEST_BOOL_NOT_SET",
+			def:      false,
+			expected: false,
+			setEnv:   false,
+		},
+		{
+			name:     "env var not set - default true",
+			key:      "TEST_BOOL_NOT_SET2",
+			def:      true,
+			expected: true,
+			setEnv:   false,
+		},
+		{
+			name:     "env var set to 'true'",
+			key:      "TEST_BOOL_TRUE",
+			def:      false,
+			expected: true,
+			setEnv:   true,
+			envValue: "true",
+		},
+		{
+			name:     "env var set to 'TRUE'",
+			key:      "TEST_BOOL_TRUE_UPPER",
+			def:      false,
+			expected: true,
+			setEnv:   true,
+			envValue: "TRUE",
+		},
+		{
+			name:     "env var set to '1'",
+			key:      "TEST_BOOL_ONE",
+			def:      false,
+			expected: true,
+			setEnv:   true,
+			envValue: "1",
+		},
+		{
+			name:     "env var set to 'false'",
+			key:      "TEST_BOOL_FALSE",
+			def:      true,
+			expected: false,
+			setEnv:   true,
+			envValue: "false",
+		},
+		{
+			name:     "env var set to '0'",
+			key:      "TEST_BOOL_ZERO",
+			def:      true,
+			expected: false,
+			setEnv:   true,
+			envValue: "0",
+		},
+		{
+			name:     "env var set to other value",
+			key:      "TEST_BOOL_OTHER",
+			def:      true,
+			expected: false,
+			setEnv:   true,
+			envValue: "other",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup
+			if tc.setEnv {
+				t.Setenv(tc.key, tc.envValue)
+			}
+
+			// Test
+			result := getEnvBoolWithDefault(tc.key, tc.def)
+
+			if result != tc.expected {
+				t.Errorf("Expected %t, got %t", tc.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/auth/oidc_test.go
+++ b/pkg/auth/oidc_test.go
@@ -282,13 +282,13 @@ func TestOIDCProviderGlobPatterns(t *testing.T) {
 		email    string
 		expected bool
 	}{
-		{"user@example.com", true},      // matches *@example.com
-		{"test@example.com", true},      // matches *@example.com
-		{"admin.user@company.org", true}, // matches admin.*@company.*
+		{"user@example.com", true},         // matches *@example.com
+		{"test@example.com", true},         // matches *@example.com
+		{"admin.user@company.org", true},   // matches admin.*@company.*
 		{"admin.test@company.co.uk", true}, // matches admin.*@company.*
-		{"user@other.com", false},       // no match
-		{"regular@company.org", false},  // no match (not admin.*)
-		{"admin@example.com", true},     // matches *@example.com
+		{"user@other.com", false},          // no match
+		{"regular@company.org", false},     // no match (not admin.*)
+		{"admin@example.com", true},        // matches *@example.com
 	}
 
 	for _, tc := range testCases {

--- a/pkg/mcp-proxy/main.go
+++ b/pkg/mcp-proxy/main.go
@@ -56,6 +56,7 @@ func Run(
 	oidcUserIDField string,
 	oidcProviderName string,
 	oidcAllowedUsers []string,
+	oidcAllowedUsersGlob []string,
 	password string,
 	passwordHash string,
 	trustedProxy []string,
@@ -176,6 +177,7 @@ func Run(
 			oidcClientID,
 			oidcClientSecret,
 			oidcAllowedUsers,
+			oidcAllowedUsersGlob,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to create OIDC provider: %w", err)


### PR DESCRIPTION
This PR adds glob pattern support for OIDC allowed users.\n\n- Supports patterns like *@example.com and alice*\n- Preserves existing exact-match behavior for backwards compatibility\n\nPlease let me know if you prefer a different title or wording.