### PR TITLE
feat(auth): add no-provider-auto-select flag to disable auto-redirect

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -27,10 +27,11 @@ Complete reference for all MCP Auth Proxy configuration options.
 
 #### Password Authentication
 
-| Option            | Environment Variable | Default | Description                                                         |
-| ----------------- | -------------------- | ------- | ------------------------------------------------------------------- |
-| `--password`      | `PASSWORD`           | -       | Plain text password for authentication (will be hashed with bcrypt) |
-| `--password-hash` | `PASSWORD_HASH`      | -       | Bcrypt hash of password for authentication                          |
+| Option                      | Environment Variable      | Default | Description                                                                                  |
+| --------------------------- | ------------------------- | ------- | -------------------------------------------------------------------------------------------- |
+| `--no-provider-auto-select` | `NO_PROVIDER_AUTO_SELECT` | `false` | Disable auto-redirect when only one OAuth/OIDC provider is configured and no password is set |
+| `--password`                | `PASSWORD`                | -       | Plain text password for authentication (will be hashed with bcrypt)                          |
+| `--password-hash`           | `PASSWORD_HASH`           | -       | Bcrypt hash of password for authentication                                                   |
 
 #### Google OAuth
 

--- a/main.go
+++ b/main.go
@@ -89,6 +89,7 @@ func main() {
 	var oidcProviderName string
 	var oidcAllowedUsers string
 	var oidcAllowedUsersGlob string
+	var noProviderAutoSelect bool
 	var password string
 	var passwordHash string
 	var proxyBearerToken string
@@ -195,6 +196,7 @@ func main() {
 				oidcProviderName,
 				oidcAllowedUsersList,
 				oidcAllowedUsersGlobList,
+				noProviderAutoSelect,
 				password,
 				passwordHash,
 				trustedProxiesList,
@@ -239,6 +241,7 @@ func main() {
 	rootCmd.Flags().StringVar(&oidcAllowedUsersGlob, "oidc-allowed-users-glob", getEnvWithDefault("OIDC_ALLOWED_USERS_GLOB", ""), "Comma-separated list of glob patterns for allowed OIDC users")
 
 	// Password authentication
+	rootCmd.Flags().BoolVar(&noProviderAutoSelect, "no-provider-auto-select", getEnvBoolWithDefault("NO_PROVIDER_AUTO_SELECT", false), "Disable auto-redirect when only one OAuth/OIDC provider is configured and no password is set")
 	rootCmd.Flags().StringVar(&password, "password", getEnvWithDefault("PASSWORD", ""), "Plain text password for authentication (will be hashed with bcrypt)")
 	rootCmd.Flags().StringVar(&passwordHash, "password-hash", getEnvWithDefault("PASSWORD_HASH", ""), "Bcrypt hash of password for authentication")
 

--- a/pkg/idp/idp_test.go
+++ b/pkg/idp/idp_test.go
@@ -64,7 +64,7 @@ func setupTestServer(t *testing.T) (*httptest.Server, repository.Repository, str
 	})
 
 	// Create auth router and IDP router
-	authRouter, err := auth.NewAuthRouter([]string{})
+	authRouter, err := auth.NewAuthRouter([]string{}, false)
 	require.NoError(t, err)
 
 	logger, _ := zap.NewDevelopment()

--- a/pkg/mcp-proxy/main.go
+++ b/pkg/mcp-proxy/main.go
@@ -57,6 +57,7 @@ func Run(
 	oidcProviderName string,
 	oidcAllowedUsers []string,
 	oidcAllowedUsersGlob []string,
+	noProviderAutoSelect bool,
 	password string,
 	passwordHash string,
 	trustedProxy []string,
@@ -201,7 +202,7 @@ func Run(
 		passwordHashes = append(passwordHashes, passwordHash)
 	}
 
-	authRouter, err := auth.NewAuthRouter(passwordHashes, providers...)
+	authRouter, err := auth.NewAuthRouter(passwordHashes, noProviderAutoSelect, providers...)
 	if err != nil {
 		return fmt.Errorf("failed to create auth router: %w", err)
 	}


### PR DESCRIPTION
## Summary

Adds a `--no-provider-auto-select` flag that disables automatic redirect to the sole configured provider when no password is set. This gives operators the option to always land on the login chooser page even if only one provider is configured.

- `AuthRouter`: new `noProviderAutoSelect` field respected in `handleLogin`.
- `mcp-proxy`: thread flag into `Run` and `auth.NewAuthRouter`.
- Tests updated to cover both behaviors.
- Docs updated to document the new flag.

## Type of Change

- [x] **feat**: A new feature
- [ ] **fix**: A bug fix
- [x] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] **refactor**: A code change that neither fixes a bug nor adds a feature
- [ ] **perf**: A code change that improves performance
- [x] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to our CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit

## Related Issues