### PR TITLE
docs: align proxy options table columns

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -117,11 +117,11 @@ You can use both exact matching and glob patterns for OIDC user authorization:
 
 ### Proxy Options
 
-| Option                 | Environment Variable | Default | Description                                                                                           |
-| ---------------------- | -------------------- | ------- | ----------------------------------------------------------------------------------------------------- |
-| `--proxy-bearer-token` | `PROXY_BEARER_TOKEN` | -       | Bearer token to add to Authorization header when proxying requests                                    |
-| `--proxy-headers`      | `PROXY_HEADERS`      | -       | Comma-separated list of headers to add when proxying requests (format: Header1:Value1,Header2:Value2) |
+| Option                  | Environment Variable  | Default | Description                                                                                           |
+| ----------------------- | --------------------- | ------- | ----------------------------------------------------------------------------------------------------- |
+| `--proxy-bearer-token`  | `PROXY_BEARER_TOKEN`  | -       | Bearer token to add to Authorization header when proxying requests                                    |
+| `--proxy-headers`       | `PROXY_HEADERS`       | -       | Comma-separated list of headers to add when proxying requests (format: Header1:Value1,Header2:Value2) |
 | `--http-streaming-only` | `HTTP_STREAMING_ONLY` | `false` | Reject SSE (GET) requests and keep the backend operating in HTTP streaming-only mode                  |
-| `--trusted-proxies`    | `TRUSTED_PROXIES`    | -       | Comma-separated list of trusted proxies (IP addresses or CIDR ranges)                                 |
+| `--trusted-proxies`     | `TRUSTED_PROXIES`     | -       | Comma-separated list of trusted proxies (IP addresses or CIDR ranges)                                 |
 
 For practical configuration examples including environment variables, Docker Compose, and Kubernetes deployments, see the [Configuration Examples](./examples.md) page.


### PR DESCRIPTION
## Summary

Align column widths in the proxy options table for readability.

## Type of Change

- [ ] **feat**: A new feature
- [ ] **fix**: A bug fix
- [x] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] **refactor**: A code change that neither fixes a bug nor adds a feature
- [ ] **perf**: A code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to our CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit

## Related Issues
