### PR TITLE
fix: increase VARCHAR(255) to VARCHAR(512) for token signature fields

### DIFF
--- a/pkg/repository/sql.go
+++ b/pkg/repository/sql.go
@@ -22,43 +22,43 @@ type sqlRepository struct {
 }
 
 type authorizeCodeSession struct {
-	Code      string `gorm:"primaryKey;size:255"`
+	Code      string `gorm:"primaryKey;size:512"`
 	Request   []byte `gorm:"not null"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
 
 type accessTokenSession struct {
-	Signature string `gorm:"primaryKey;size:255"`
+	Signature string `gorm:"primaryKey;size:512"`
 	Request   []byte `gorm:"not null"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
 
 type refreshTokenSession struct {
-	Signature       string `gorm:"primaryKey;size:255"`
-	AccessSignature string `gorm:"size:255"`
+	Signature       string `gorm:"primaryKey;size:512"`
+	AccessSignature string `gorm:"size:512"`
 	Request         []byte `gorm:"not null"`
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
 }
 
 type clientRecord struct {
-	ID        string `gorm:"primaryKey;size:255"`
+	ID        string `gorm:"primaryKey;size:512"`
 	Client    []byte `gorm:"not null"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
 
 type pkceRequestSession struct {
-	Signature string `gorm:"primaryKey;size:255"`
+	Signature string `gorm:"primaryKey;size:512"`
 	Request   []byte `gorm:"not null"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
 
 type authorizeRequestRecord struct {
-	RequestID string `gorm:"primaryKey;size:255"`
+	RequestID string `gorm:"primaryKey;size:512"`
 	Request   []byte `gorm:"not null"`
 	CreatedAt time.Time
 	UpdatedAt time.Time


### PR DESCRIPTION
## Summary

OAuth token signatures (access tokens, refresh tokens, authorization codes, PKCE signatures) regularly exceed 255 characters (~420 chars observed in production with Google OAuth + PostgreSQL).

This causes INSERT failures:
```
ERROR: value too long for type character varying(255) (SQLSTATE 22001)
```

## Changes

Widen all 7 affected GORM model fields in `pkg/repository/sql.go` from `size:255` to `size:512`:

- `authorizeCodeSession.Code`
- `accessTokenSession.Signature`
- `refreshTokenSession.Signature`
- `refreshTokenSession.AccessSignature`
- `clientRecord.ID`
- `pkceRequestSession.Signature`
- `authorizeRequestRecord.RequestID`

## Migration note

GORM `AutoMigrate` creates new tables with the correct size but does not ALTER existing columns. Existing PostgreSQL installations need a one-time migration:

```sql
ALTER TABLE access_token_sessions ALTER COLUMN signature TYPE VARCHAR(512);
ALTER TABLE refresh_token_sessions ALTER COLUMN signature TYPE VARCHAR(512);
ALTER TABLE refresh_token_sessions ALTER COLUMN access_signature TYPE VARCHAR(512);
ALTER TABLE authorize_code_sessions ALTER COLUMN code TYPE VARCHAR(512);
ALTER TABLE pkce_request_sessions ALTER COLUMN signature TYPE VARCHAR(512);
ALTER TABLE client_records ALTER COLUMN id TYPE VARCHAR(512);
ALTER TABLE authorize_request_records ALTER COLUMN request_id TYPE VARCHAR(512);
```

SQLite and BoltDB backends are unaffected (no column size enforcement).

Fixes #111