### PR TITLE
fix: increase OAuth signature column sizes from 255 to 512

### DIFF
--- a/pkg/repository/sql.go
+++ b/pkg/repository/sql.go
@@ -22,43 +22,43 @@ type sqlRepository struct {
 }
 
 type authorizeCodeSession struct {
-	Code      string `gorm:"primaryKey;size:255"`
+	Code      string `gorm:"primaryKey;size:512"`
 	Request   []byte `gorm:"not null"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
 
 type accessTokenSession struct {
-	Signature string `gorm:"primaryKey;size:255"`
+	Signature string `gorm:"primaryKey;size:512"`
 	Request   []byte `gorm:"not null"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
 
 type refreshTokenSession struct {
-	Signature       string `gorm:"primaryKey;size:255"`
-	AccessSignature string `gorm:"size:255"`
+	Signature       string `gorm:"primaryKey;size:512"`
+	AccessSignature string `gorm:"size:512"`
 	Request         []byte `gorm:"not null"`
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
 }
 
 type clientRecord struct {
-	ID        string `gorm:"primaryKey;size:255"`
+	ID        string `gorm:"primaryKey;size:512"`
 	Client    []byte `gorm:"not null"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
 
 type pkceRequestSession struct {
-	Signature string `gorm:"primaryKey;size:255"`
+	Signature string `gorm:"primaryKey;size:512"`
 	Request   []byte `gorm:"not null"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
 
 type authorizeRequestRecord struct {
-	RequestID string `gorm:"primaryKey;size:255"`
+	RequestID string `gorm:"primaryKey;size:512"`
 	Request   []byte `gorm:"not null"`
 	CreatedAt time.Time
 	UpdatedAt time.Time


### PR DESCRIPTION
Increases VARCHAR size for OAuth-related columns from 255 to 512 characters to accommodate longer OAuth signatures and tokens.

This fixes a postgres error where OAuth signatures from certain providers (like ChatGPT) exceed the VARCHAR(255) limit, causing authentication failures.

Changes:
- authorizeCodeSession.Code: 255 → 512
- accessTokenSession.Signature: 255 → 512
- refreshTokenSession.Signature: 255 → 512
- refreshTokenSession.AccessSignature: 255 → 512
- pkceRequestSession.Signature: 255 → 512
- clientRecord.ID: 255 → 512
- authorizeRequestRecord.RequestID: 255 → 512

Error fixed: "value too long for type character varying(255) (SQLSTATE 22001)"

