### PR TITLE
fix: follow backend 307/308 redirects in transparent proxy

### DIFF
--- a/pkg/backend/transparent.go
+++ b/pkg/backend/transparent.go
@@ -1,8 +1,10 @@
 package backend
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -38,6 +40,79 @@ func NewTransparentBackend(logger *zap.Logger, u *url.URL, trusted []string) (Ba
 	}, nil
 }
 
+const maxBackendRedirects = 10
+
+// redirectFollowingTransport wraps an http.RoundTripper to transparently
+// follow 307/308 redirects from backend servers. This is needed because
+// httputil.ReverseProxy uses Transport.RoundTrip() directly, which does
+// not follow redirects. Many MCP backends (Starlette/FastAPI) redirect
+// /mcp → /mcp/ via 307, which POST-based MCP clients won't follow.
+type redirectFollowingTransport struct {
+	base       http.RoundTripper
+	targetHost string // only follow redirects to this host
+}
+
+func (t *redirectFollowingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Buffer body upfront so we can replay it on redirect.
+	// MCP JSON-RPC payloads are small, so this is fine.
+	var bodyBytes []byte
+	if req.Body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read request body: %w", err)
+		}
+		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	}
+
+	for i := 0; i <= maxBackendRedirects; i++ {
+		resp, err := t.base.RoundTrip(req)
+		if err != nil {
+			return nil, err
+		}
+
+		// Only follow 307 (Temporary) and 308 (Permanent) redirects.
+		// These preserve the original method and body per HTTP spec.
+		if resp.StatusCode != http.StatusTemporaryRedirect &&
+			resp.StatusCode != http.StatusPermanentRedirect {
+			return resp, nil
+		}
+
+		location := resp.Header.Get("Location")
+		if location == "" {
+			return resp, nil
+		}
+
+		// Resolve relative Location against the request URL
+		newURL, err := req.URL.Parse(location)
+		if err != nil {
+			return resp, nil
+		}
+
+		// Security: only follow redirects to the same backend host.
+		// Don't leak Authorization headers or body to arbitrary hosts.
+		if newURL.Host != "" && newURL.Host != t.targetHost {
+			return resp, nil
+		}
+
+		// Drain and close the redirect response body
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+
+		// Clone the request for the next hop, replaying the body
+		newReq := req.Clone(req.Context())
+		newReq.URL = newURL
+		newReq.Host = newURL.Host
+		if bodyBytes != nil {
+			newReq.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+			newReq.ContentLength = int64(len(bodyBytes))
+		}
+		req = newReq
+	}
+
+	return nil, fmt.Errorf("backend exceeded maximum redirects (%d)", maxBackendRedirects)
+}
+
 func (p *TransparentBackend) Run(ctx context.Context) (http.Handler, error) {
 	p.ctxLock.Lock()
 	defer p.ctxLock.Unlock()
@@ -46,6 +121,10 @@ func (p *TransparentBackend) Run(ctx context.Context) (http.Handler, error) {
 	}
 	p.ctx = ctx
 	rp := httputil.ReverseProxy{
+		Transport: &redirectFollowingTransport{
+			base:       http.DefaultTransport,
+			targetHost: p.url.Host,
+		},
 		Rewrite: func(pr *httputil.ProxyRequest) {
 			pr.SetURL(p.url)
 			if p.isTrusted(pr.In.RemoteAddr) {

--- a/pkg/backend/transparent_test.go
+++ b/pkg/backend/transparent_test.go
@@ -3,9 +3,11 @@ package backend
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -96,6 +98,62 @@ func TestTransparentBackendWithInvalidProxy(t *testing.T) {
 	require.Equal(t, "192.0.2.1", header.Get(("X-Forwarded-For")))
 	require.Equal(t, "example.com", header.Get(("X-Forwarded-Host")))
 	require.Equal(t, "http", header.Get(("X-Forwarded-Proto")))
+}
+
+func TestTransparentBackendFollows307Redirect(t *testing.T) {
+	r := gin.New()
+	// Simulate Starlette's redirect_slashes: /mcp → 307 → /mcp/
+	r.POST("/mcp", func(c *gin.Context) {
+		c.Redirect(http.StatusTemporaryRedirect, "/mcp/")
+	})
+	r.POST("/mcp/", func(c *gin.Context) {
+		body, _ := io.ReadAll(c.Request.Body)
+		c.JSON(http.StatusOK, gin.H{
+			"received": string(body),
+			"method":   c.Request.Method,
+		})
+	})
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+	u, _ := url.Parse(ts.URL)
+
+	be, err := NewTransparentBackend(zap.NewNop(), u, []string{})
+	require.NoError(t, err)
+	handler, err := be.Run(context.Background())
+	require.NoError(t, err)
+
+	body := `{"jsonrpc":"2.0","method":"initialize"}`
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "should follow 307 internally")
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.Equal(t, body, resp["received"], "body must be preserved across redirect")
+	require.Equal(t, "POST", resp["method"], "method must be preserved")
+}
+
+func TestTransparentBackendRedirectLoopProtection(t *testing.T) {
+	r := gin.New()
+	r.POST("/loop", func(c *gin.Context) {
+		c.Redirect(http.StatusTemporaryRedirect, "/loop")
+	})
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+	u, _ := url.Parse(ts.URL)
+
+	be, err := NewTransparentBackend(zap.NewNop(), u, []string{})
+	require.NoError(t, err)
+	handler, err := be.Run(context.Background())
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/loop", strings.NewReader("{}"))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadGateway, rr.Code, "should fail on redirect loop")
 }
 
 func TestTransparentBackendRun(t *testing.T) {


### PR DESCRIPTION
## What

`TransparentBackend` now follows 307/308 redirects from the upstream MCP server
before returning to the client.

Closes #115

## Why

Starlette/FastAPI backends (Python MCP SDK, FastMCP, LiteLLM) redirect `/mcp` →
`/mcp/` via 307 by default (`redirect_slashes=True`). POST-based MCP clients
(Claude.ai, ChatGPT, Cursor) won't follow this per HTTP spec, causing silent
failures.

## How

A `redirectFollowingTransport` wrapper is added to `pkg/backend/transparent.go`:
- Buffers the request body before the first hop (MCP payloads are small JSON-RPC)
- On 307/308, replays the body to the `Location` URL
- Security: only follows redirects to the same backend host
- Caps at 10 redirects to prevent loops

## Testing

Two new test cases in `pkg/backend/transparent_test.go`:
- `TestTransparentBackendFollows307Redirect` — verifies method and body preserved
- `TestTransparentBackendRedirectLoopProtection` — verifies loop detection returns 502

## Real-world scenario: mcp-auth-proxy in front of LiteLLM

A common setup is LiteLLM already exposed externally (e.g. `https://llm.example.com`)
with its MCP endpoint available as a side-effect. mcp-auth-proxy is then added in
front to enforce authentication.

If the proxy is configured with the **internal** backend URL (`http://litellm:4000`)
but LiteLLM is configured to know its **public** identity (e.g. via Traefik's
`X-Forwarded-Host` middleware), Starlette generates an absolute redirect Location
like `https://llm.example.com/mcp/`. The redirect-following transport handles this
correctly: the host matches the target host, so the redirect is followed internally.

However, if the scheme differs (backend is `http://` but Location is `https://`),
the transport will attempt a TLS connection to a plain-HTTP backend and fail with
a handshake error. The correct configuration in this case is to use the **external**
URL as the backend (`https://llm.example.com`) so that scheme and host both match
the redirect target.

This is worth noting as it affects anyone who:
1. Exposes LiteLLM externally with a configured public hostname
2. Adds mcp-auth-proxy using the internal Docker service URL as backend