### PR TITLE
fix: widen OAuth signature columns from VARCHAR(255) to VARCHAR(512)

### DIFF
--- a/pkg/repository/sql.go
+++ b/pkg/repository/sql.go
@@ -22,43 +22,43 @@ type sqlRepository struct {
 }
 
 type authorizeCodeSession struct {
-	Code      string `gorm:"primaryKey;size:255"`
+	Code      string `gorm:"primaryKey;size:512"`
 	Request   []byte `gorm:"not null"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
 
 type accessTokenSession struct {
-	Signature string `gorm:"primaryKey;size:255"`
+	Signature string `gorm:"primaryKey;size:512"`
 	Request   []byte `gorm:"not null"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
 
 type refreshTokenSession struct {
-	Signature       string `gorm:"primaryKey;size:255"`
-	AccessSignature string `gorm:"size:255"`
+	Signature       string `gorm:"primaryKey;size:512"`
+	AccessSignature string `gorm:"size:512"`
 	Request         []byte `gorm:"not null"`
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
 }
 
 type clientRecord struct {
-	ID        string `gorm:"primaryKey;size:255"`
+	ID        string `gorm:"primaryKey;size:512"`
 	Client    []byte `gorm:"not null"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
 
 type pkceRequestSession struct {
-	Signature string `gorm:"primaryKey;size:255"`
+	Signature string `gorm:"primaryKey;size:512"`
 	Request   []byte `gorm:"not null"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
 
 type authorizeRequestRecord struct {
-	RequestID string `gorm:"primaryKey;size:255"`
+	RequestID string `gorm:"primaryKey;size:512"`
 	Request   []byte `gorm:"not null"`
 	CreatedAt time.Time
 	UpdatedAt time.Time


### PR DESCRIPTION
## Summary

Widen all 7 OAuth-related GORM model fields from `size:255` to `size:512`.
OAuth token signatures regularly exceed 255 characters (~420 chars observed
with Google OAuth + PostgreSQL), causing INSERT failures.

Fixes #111

## Type of Change

- [x] **fix**: A bug fix

## Related Issues

Closes #111

Co-authored-by: Alex Leonov <alex.leonov@yum.com>
Co-authored-by: Arnaud Barisain-Monrose <arnaud@arnaud.moe>