### PR TITLE
fix: normalize external URL with trailing slash per RFC 3986

### DIFF
--- a/pkg/mcp-proxy/main.go
+++ b/pkg/mcp-proxy/main.go
@@ -84,9 +84,11 @@ func Run(
 	if err != nil {
 		return fmt.Errorf("failed to parse external URL: %w", err)
 	}
-	if parsedExternalURL.Path != "" {
+	if parsedExternalURL.Path != "" && parsedExternalURL.Path != "/" {
 		return fmt.Errorf("external URL must not have a path, got: %s", parsedExternalURL.Path)
 	}
+	parsedExternalURL.Path = "/"
+	externalURL = parsedExternalURL.String()
 
 	if (tlsCertFile == "") != (tlsKeyFile == "") {
 		return fmt.Errorf("both TLS certificate and key files must be provided together")

--- a/pkg/mcp-proxy/main_test.go
+++ b/pkg/mcp-proxy/main_test.go
@@ -10,6 +10,56 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestRun_NormalizesExternalURLTrailingSlash(t *testing.T) {
+	originalNewProxyRouter := newProxyRouter
+	t.Cleanup(func() {
+		newProxyRouter = originalNewProxyRouter
+	})
+
+	cases := []struct {
+		name        string
+		input       string
+		wantURL     string
+		wantErr     bool
+		errContains string
+	}{
+		{name: "no trailing slash", input: "https://example.com", wantURL: "https://example.com/"},
+		{name: "with trailing slash", input: "https://example.com/", wantURL: "https://example.com/"},
+		{name: "with path", input: "https://example.com/foo", wantErr: true, errContains: "must not have a path"},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var receivedURL string
+			newProxyRouter = func(externalURL string, proxyHandler http.Handler, publicKey *rsa.PublicKey, proxyHeaders http.Header, httpStreamingOnly bool) (*proxy.ProxyRouter, error) {
+				receivedURL = externalURL
+				return nil, errors.New("stop early")
+			}
+
+			err := Run(
+				":0", ":0", false, "", "", false, "", "",
+				t.TempDir(), "local", "",
+				tt.input,
+				"", "", nil, nil,
+				"", "", nil, nil,
+				"", "", "", nil, "", "", nil, nil, nil, nil,
+				false, "", "", nil, nil, "",
+				[]string{"http://example.com"}, false,
+			)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errContains)
+				return
+			}
+
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "stop early")
+			require.Equal(t, tt.wantURL, receivedURL)
+		})
+	}
+}
+
 func TestRun_PassesHTTPStreamingOnlyToProxyRouter(t *testing.T) {
 	originalNewProxyRouter := newProxyRouter
 	t.Cleanup(func() {

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -101,6 +102,32 @@ func TestProxyRouter_HandleProxy_ValidToken(t *testing.T) {
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestProxyRouter_ProtectedResourceTrailingSlash(t *testing.T) {
+	_, publicKey, err := generateRSAKeyPair()
+	require.NoError(t, err)
+
+	proxyRouter, err := NewProxyRouter("https://example.com/", http.NotFoundHandler(), publicKey, http.Header{}, false)
+	require.NoError(t, err)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	proxyRouter.SetupRoutes(router)
+
+	req, err := http.NewRequest("GET", OauthProtectedResourceEndpoint, nil)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp protectedResourceResponse
+	err = json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/", resp.Resource)
+	assert.Equal(t, []string{"https://example.com/"}, resp.AuthorizationServers)
 }
 
 func TestProxyRouter_HTTPStreamingOnlyRejectsSSE(t *testing.T) {


### PR DESCRIPTION
## Summary

Normalize `EXTERNAL_URL` to always include a trailing slash (RFC 3986 Section 6.2.3 scheme-based normalization), so the `resource` URI in `/.well-known/oauth-protected-resource` matches the canonical form expected by clients like claude.ai.

- Allow `EXTERNAL_URL` with or without trailing slash (e.g. both `https://example.com` and `https://example.com/` are accepted)
- Reject actual paths (e.g. `https://example.com/foo`) as before
- Internally normalize to trailing-slash form before passing to all downstream components

## Type of Change

- [x] **fix**: A bug fix

## Related Issues

Closes #123