### PR TITLE
fix: generate server-side OAuth state when client omits it

### DIFF
--- a/pkg/idp/idp.go
+++ b/pkg/idp/idp.go
@@ -114,6 +114,22 @@ func (a *IDPRouter) SetupRoutes(router gin.IRouter) {
 func (a *IDPRouter) handleAuth(c *gin.Context) {
 	ctx := c.Request.Context()
 
+	// RFC 6749 makes state RECOMMENDED, not REQUIRED, but fosite enforces
+	// minimum entropy (8 chars). Generate a server-side state for clients
+	// that omit it (e.g., MCP Inspector, Cursor CLI) so they can complete
+	// the OAuth flow. The generated state is echoed back in the redirect;
+	// clients that didn't send state will simply ignore it.
+	if c.Request.URL.Query().Get("state") == "" {
+		state, err := utils.GenerateState()
+		if err != nil {
+			a.provider.WriteAuthorizeError(ctx, c.Writer, nil, fosite.ErrServerError.WithWrap(err))
+			return
+		}
+		q := c.Request.URL.Query()
+		q.Set("state", state)
+		c.Request.URL.RawQuery = q.Encode()
+	}
+
 	ar, err := a.provider.NewAuthorizeRequest(ctx, c.Request)
 	if err != nil {
 		a.provider.WriteAuthorizeError(ctx, c.Writer, ar, err)

--- a/pkg/idp/idp_test.go
+++ b/pkg/idp/idp_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
@@ -270,4 +271,145 @@ func TestPrivateClient(t *testing.T) {
 	require.True(t, ok)
 	require.NotEmpty(t, newAccessToken)
 	require.NotEqual(t, originalAccessToken, newAccessToken, "Access token should be different after refresh")
+}
+
+// registerTestClient is a helper that registers a private OAuth client and returns the registration response.
+func registerTestClient(t *testing.T, serverURL string) registrationResponse {
+	t.Helper()
+
+	regReq := registrationRequest{
+		ClientName:              "Test OAuth Client",
+		GrantTypes:              []string{"authorization_code", "refresh_token"},
+		ResponseTypes:           []string{"code"},
+		TokenEndpointAuthMethod: "client_secret_basic",
+		Scope:                   "test",
+		RedirectURIs:            []string{"http://localhost:8080/callback"},
+	}
+
+	reqBody, err := json.Marshal(regReq)
+	require.NoError(t, err)
+
+	resp, err := http.Post(serverURL+RegistrationEndpoint, "application/json", bytes.NewReader(reqBody))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	var regResp registrationResponse
+	err = json.NewDecoder(resp.Body).Decode(&regResp)
+	require.NoError(t, err)
+
+	return regResp
+}
+
+// testAuthFlowWithURL performs the OAuth authorization flow given a raw authorization URL
+// and returns the callback URL after authorization completes.
+func testAuthFlowWithURL(t *testing.T, serverURL, authURL string) *url.URL {
+	t.Helper()
+
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	client := &http.Client{
+		Jar: jar,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	// Step 1: Make initial authorization request
+	authResp, err := client.Get(authURL)
+	require.NoError(t, err)
+	defer authResp.Body.Close()
+
+	require.Contains(t, []int{http.StatusFound, http.StatusSeeOther}, authResp.StatusCode,
+		"expected redirect, got %d", authResp.StatusCode)
+	location := authResp.Header.Get("Location")
+	require.NotEmpty(t, location)
+	require.Contains(t, location, strings.ReplaceAll(AuthorizationReturnEndpoint, ":ar_id", ""))
+
+	// Step 2: Follow the redirect to complete authorization
+	authReturnResp, err := client.Get(serverURL + location)
+	require.NoError(t, err)
+	defer authReturnResp.Body.Close()
+
+	require.Contains(t, []int{http.StatusFound, http.StatusSeeOther}, authReturnResp.StatusCode,
+		"expected redirect with authorization code, got %d", authReturnResp.StatusCode)
+	callbackLocation := authReturnResp.Header.Get("Location")
+	require.NotEmpty(t, callbackLocation)
+
+	callbackURL, err := url.Parse(callbackLocation)
+	require.NoError(t, err)
+	require.NotEmpty(t, callbackURL.Query().Get("code"), "callback URL should contain an authorization code")
+
+	return callbackURL
+}
+
+func TestAuthWithoutState(t *testing.T) {
+	server, _, _ := setupTestServer(t)
+	regResp := registerTestClient(t, server.URL)
+
+	// Build authorization URL manually WITHOUT a state parameter
+	authURL := fmt.Sprintf("%s%s?response_type=code&client_id=%s&redirect_uri=%s",
+		server.URL, AuthorizationEndpoint, regResp.ClientID,
+		url.QueryEscape("http://localhost:8080/callback"))
+
+	callbackURL := testAuthFlowWithURL(t, server.URL, authURL)
+
+	// Server should have generated a state and echoed it back
+	require.NotEmpty(t, callbackURL.Query().Get("state"), "server should generate a state when client omits it")
+
+	// Exchange authorization code for tokens
+	code := callbackURL.Query().Get("code")
+	tokenReq := url.Values{}
+	tokenReq.Set("grant_type", "authorization_code")
+	tokenReq.Set("code", code)
+	tokenReq.Set("redirect_uri", "http://localhost:8080/callback")
+	tokenReq.Set("client_id", regResp.ClientID)
+	tokenReq.Set("client_secret", regResp.ClientSecret)
+
+	tokenResp, err := http.PostForm(server.URL+TokenEndpoint, tokenReq)
+	require.NoError(t, err)
+	defer tokenResp.Body.Close()
+
+	require.Equal(t, http.StatusOK, tokenResp.StatusCode)
+
+	var tokenResult map[string]any
+	err = json.NewDecoder(tokenResp.Body).Decode(&tokenResult)
+	require.NoError(t, err)
+	require.NotEmpty(t, tokenResult["access_token"])
+}
+
+func TestAuthWithEmptyState(t *testing.T) {
+	server, _, _ := setupTestServer(t)
+	regResp := registerTestClient(t, server.URL)
+
+	// Build authorization URL with an empty state parameter
+	authURL := fmt.Sprintf("%s%s?response_type=code&client_id=%s&redirect_uri=%s&state=",
+		server.URL, AuthorizationEndpoint, regResp.ClientID,
+		url.QueryEscape("http://localhost:8080/callback"))
+
+	callbackURL := testAuthFlowWithURL(t, server.URL, authURL)
+
+	// Server should have generated a state and echoed it back
+	require.NotEmpty(t, callbackURL.Query().Get("state"), "server should generate a state when client sends empty state")
+
+	// Exchange authorization code for tokens
+	code := callbackURL.Query().Get("code")
+	tokenReq := url.Values{}
+	tokenReq.Set("grant_type", "authorization_code")
+	tokenReq.Set("code", code)
+	tokenReq.Set("redirect_uri", "http://localhost:8080/callback")
+	tokenReq.Set("client_id", regResp.ClientID)
+	tokenReq.Set("client_secret", regResp.ClientSecret)
+
+	tokenResp, err := http.PostForm(server.URL+TokenEndpoint, tokenReq)
+	require.NoError(t, err)
+	defer tokenResp.Body.Close()
+
+	require.Equal(t, http.StatusOK, tokenResp.StatusCode)
+
+	var tokenResult map[string]any
+	err = json.NewDecoder(tokenResp.Body).Decode(&tokenResult)
+	require.NoError(t, err)
+	require.NotEmpty(t, tokenResult["access_token"])
 }


### PR DESCRIPTION
## Summary

MCP clients like MCP Inspector and Cursor CLI send authorization requests without a state parameter. Fosite enforces minimum entropy (8 chars) on state, rejecting these requests with invalid_state.

RFC 6749 makes state RECOMMENDED, not REQUIRED. Generate a server-side state for clients that omit it so they can complete the OAuth flow. The generated state is echoed back in the redirect; clients that didn't send state will simply ignore it.

## Type of Change

- [ ] **feat**: A new feature
- [X] **fix**: A bug fix
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] **refactor**: A code change that neither fixes a bug nor adds a feature
- [ ] **perf**: A code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to our CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit

## Related Issues

<!-- Example: Closes #123 or Fixes #456. Leave blank if no related issues. -->

Fixes #94
