### PR TITLE
feat: forward user identity to upstream via X-Forwarded-User header

### DIFF
--- a/main.go
+++ b/main.go
@@ -130,6 +130,7 @@ type proxyRunnerFunc func(
 	proxyBearerToken string,
 	proxyTarget []string,
 	httpStreamingOnly bool,
+	passUserHeaders bool,
 ) error
 
 func main() {
@@ -175,6 +176,7 @@ func newRootCommand(run proxyRunnerFunc) *cobra.Command {
 	var proxyBearerToken string
 	var proxyHeaders string
 	var httpStreamingOnly bool
+	var passUserHeaders bool
 	var trustedProxies string
 
 	rootCmd := &cobra.Command{
@@ -294,6 +296,7 @@ func newRootCommand(run proxyRunnerFunc) *cobra.Command {
 				proxyBearerToken,
 				args,
 				httpStreamingOnly,
+				passUserHeaders,
 			); err != nil {
 				panic(err)
 			}
@@ -347,6 +350,7 @@ func newRootCommand(run proxyRunnerFunc) *cobra.Command {
 	rootCmd.Flags().StringVar(&trustedProxies, "trusted-proxies", getEnvWithDefault("TRUSTED_PROXIES", ""), "Comma-separated list of trusted proxies (IP addresses or CIDR ranges)")
 	rootCmd.Flags().StringVar(&proxyHeaders, "proxy-headers", getEnvWithDefault("PROXY_HEADERS", ""), "Comma-separated list of headers to add when proxying requests (format: Header1:Value1,Header2:Value2)")
 	rootCmd.Flags().BoolVar(&httpStreamingOnly, "http-streaming-only", getEnvBoolWithDefault("HTTP_STREAMING_ONLY", false), "Reject SSE (GET) requests and keep the backend in HTTP streaming-only mode")
+	rootCmd.Flags().BoolVar(&passUserHeaders, "pass-user-headers", getEnvBoolWithDefault("PASS_USER_HEADERS", false), "Forward authenticated user identity as X-Forwarded-User header to upstream")
 
 	return rootCmd
 }

--- a/main_test.go
+++ b/main_test.go
@@ -344,6 +344,7 @@ func TestNewRootCommand_HTTPStreamingOnlyFlag(t *testing.T) {
 		proxyBearerToken string,
 		proxyTarget []string,
 		httpStreamingOnly bool,
+		passUserHeaders bool,
 	) error {
 		streamingOnly = httpStreamingOnly
 		receivedTargets = proxyTarget
@@ -407,6 +408,7 @@ func TestNewRootCommand_HTTPStreamingOnlyFromEnv(t *testing.T) {
 		proxyBearerToken string,
 		proxyTarget []string,
 		httpStreamingOnly bool,
+		passUserHeaders bool,
 	) error {
 		streamingOnly = httpStreamingOnly
 		return nil
@@ -421,5 +423,125 @@ func TestNewRootCommand_HTTPStreamingOnlyFromEnv(t *testing.T) {
 
 	if !streamingOnly {
 		t.Fatalf("expected httpStreamingOnly to default to true from env var")
+	}
+}
+
+func TestNewRootCommand_PassUserHeadersFlag(t *testing.T) {
+	t.Setenv("PASS_USER_HEADERS", "")
+
+	var passUserHeaders bool
+	runner := proxyRunnerFunc(func(listen string,
+		tlsListen string,
+		autoTLS bool,
+		tlsHost string,
+		tlsDirectoryURL string,
+		tlsAcceptTOS bool,
+		tlsCertFile string,
+		tlsKeyFile string,
+		dataPath string,
+		repositoryBackend string,
+		repositoryDSN string,
+		externalURL string,
+		googleClientID string,
+		googleClientSecret string,
+		googleAllowedUsers []string,
+		googleAllowedWorkspaces []string,
+		githubClientID string,
+		githubClientSecret string,
+		githubAllowedUsers []string,
+		githubAllowedOrgs []string,
+		oidcConfigurationURL string,
+		oidcClientID string,
+		oidcClientSecret string,
+		oidcScopes []string,
+		oidcUserIDField string,
+		oidcProviderName string,
+		oidcAllowedUsers []string,
+		oidcAllowedUsersGlob []string,
+		oidcAllowedAttributes map[string][]string,
+		oidcAllowedAttributesGlob map[string][]string,
+		noProviderAutoSelect bool,
+		password string,
+		passwordHash string,
+		trustedProxy []string,
+		proxyHeaders []string,
+		proxyBearerToken string,
+		proxyTarget []string,
+		httpStreamingOnly bool,
+		puh bool,
+	) error {
+		passUserHeaders = puh
+		return nil
+	})
+
+	cmd := newRootCommand(runner)
+	cmd.SetArgs([]string{"--pass-user-headers", "http://backend"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected command to succeed, got error: %v", err)
+	}
+
+	if !passUserHeaders {
+		t.Fatalf("expected passUserHeaders to be true when flag is set")
+	}
+}
+
+func TestNewRootCommand_PassUserHeadersFromEnv(t *testing.T) {
+	t.Setenv("PASS_USER_HEADERS", "true")
+
+	var passUserHeaders bool
+	runner := proxyRunnerFunc(func(listen string,
+		tlsListen string,
+		autoTLS bool,
+		tlsHost string,
+		tlsDirectoryURL string,
+		tlsAcceptTOS bool,
+		tlsCertFile string,
+		tlsKeyFile string,
+		dataPath string,
+		repositoryBackend string,
+		repositoryDSN string,
+		externalURL string,
+		googleClientID string,
+		googleClientSecret string,
+		googleAllowedUsers []string,
+		googleAllowedWorkspaces []string,
+		githubClientID string,
+		githubClientSecret string,
+		githubAllowedUsers []string,
+		githubAllowedOrgs []string,
+		oidcConfigurationURL string,
+		oidcClientID string,
+		oidcClientSecret string,
+		oidcScopes []string,
+		oidcUserIDField string,
+		oidcProviderName string,
+		oidcAllowedUsers []string,
+		oidcAllowedUsersGlob []string,
+		oidcAllowedAttributes map[string][]string,
+		oidcAllowedAttributesGlob map[string][]string,
+		noProviderAutoSelect bool,
+		password string,
+		passwordHash string,
+		trustedProxy []string,
+		proxyHeaders []string,
+		proxyBearerToken string,
+		proxyTarget []string,
+		httpStreamingOnly bool,
+		puh bool,
+	) error {
+		passUserHeaders = puh
+		return nil
+	})
+
+	cmd := newRootCommand(runner)
+	cmd.SetArgs([]string{"http://backend"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected command to succeed, got error: %v", err)
+	}
+
+	if !passUserHeaders {
+		t.Fatalf("expected passUserHeaders to default to true from env var")
 	}
 }

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -66,6 +66,7 @@ const (
 	PasswordUserID   = "password_user"
 
 	SessionKeyAuthorized  = "authorized"
+	SessionKeyUserID      = "user_id"
 	SessionKeyRedirectURL = "redirect_url"
 	SessionKeyOAuthState  = "oauth_state"
 )
@@ -97,6 +98,7 @@ func (a *AuthRouter) SetupRoutes(router gin.IRouter) {
 				return
 			}
 			session.Set(SessionKeyAuthorized, true)
+			session.Set(SessionKeyUserID, user)
 			redirectURL := session.Get(SessionKeyRedirectURL)
 			if redirectURL != nil {
 				session.Delete(SessionKeyRedirectURL)
@@ -177,6 +179,7 @@ func (a *AuthRouter) handleLoginPost(c *gin.Context) {
 
 	session := sessions.Default(c)
 	session.Set(SessionKeyAuthorized, true)
+	session.Set(SessionKeyUserID, PasswordUserID)
 	redirectURL := session.Get(SessionKeyRedirectURL)
 	if redirectURL != nil {
 		session.Delete(SessionKeyRedirectURL)

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
@@ -11,6 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/oauth2"
 )
 
@@ -186,6 +188,106 @@ func TestAuthenticationFlow(t *testing.T) {
 		location := resp.Header.Get("Location")
 		require.Equal(t, "/.auth/login", location)
 	})
+}
+
+func TestAuthenticationFlow_StoresUserID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockToken := &oauth2.Token{AccessToken: "test-token"}
+	mockProvider := NewMockProvider(ctrl)
+	mockProvider.EXPECT().Name().Return("test").AnyTimes()
+	mockProvider.EXPECT().AuthURL().Return("/.auth/test").AnyTimes()
+	mockProvider.EXPECT().RedirectURL().Return("/.auth/test/callback").AnyTimes()
+	mockProvider.EXPECT().AuthCodeURL(gomock.Any()).Return("https://example.com/oauth", nil)
+	mockProvider.EXPECT().Exchange(gomock.Any(), gomock.Any()).Return(mockToken, nil)
+	mockProvider.EXPECT().Authorization(gomock.Any(), mockToken).Return(true, "jane@example.com", nil)
+
+	authRouter, err := NewAuthRouter(nil, false, mockProvider)
+	require.NoError(t, err)
+
+	router := gin.New()
+	store := memstore.NewStore([]byte("test-secret"))
+	router.Use(sessions.Sessions("session", store))
+	authRouter.SetupRoutes(router)
+	router.GET("/check-session", authRouter.RequireAuth(), func(c *gin.Context) {
+		session := sessions.Default(c)
+		userID := session.Get(SessionKeyUserID)
+		c.JSON(http.StatusOK, gin.H{"user_id": userID})
+	})
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+	client := setupClient()
+
+	// Step 1: Trigger redirect to set session
+	resp, err := client.Get(server.URL + "/check-session")
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	// Step 2: Start auth
+	resp, err = client.Get(server.URL + "/.auth/test")
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	// Step 3: Callback
+	resp, err = client.Get(server.URL + "/.auth/test/callback")
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+
+	// Step 4: Verify session contains user_id
+	resp, err = client.Get(server.URL + "/check-session")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]any
+	err = json.NewDecoder(resp.Body).Decode(&body)
+	require.NoError(t, err)
+	require.Equal(t, "jane@example.com", body["user_id"])
+}
+
+func TestPasswordLogin_StoresPasswordUserID(t *testing.T) {
+	// Generate a bcrypt hash for "testpass"
+	hash, err := bcrypt.GenerateFromPassword([]byte("testpass"), bcrypt.DefaultCost)
+	require.NoError(t, err)
+
+	authRouter, err := NewAuthRouter([]string{string(hash)}, false)
+	require.NoError(t, err)
+
+	router := gin.New()
+	store := memstore.NewStore([]byte("test-secret"))
+	router.Use(sessions.Sessions("session", store))
+	authRouter.SetupRoutes(router)
+	router.GET("/check-session", authRouter.RequireAuth(), func(c *gin.Context) {
+		session := sessions.Default(c)
+		userID := session.Get(SessionKeyUserID)
+		c.JSON(http.StatusOK, gin.H{"user_id": userID})
+	})
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+	client := setupClient()
+
+	// Step 1: POST login with correct password
+	resp, err := client.PostForm(server.URL+LoginEndpoint, map[string][]string{
+		"password": {"testpass"},
+	})
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+
+	// Step 2: Verify session contains PasswordUserID
+	resp, err = client.Get(server.URL + "/check-session")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]any
+	err = json.NewDecoder(resp.Body).Decode(&body)
+	require.NoError(t, err)
+	require.Equal(t, PasswordUserID, body["user_id"])
 }
 
 func TestLoginAutoRedirect(t *testing.T) {

--- a/pkg/idp/idp.go
+++ b/pkg/idp/idp.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/compose"
@@ -158,7 +159,14 @@ func (a *IDPRouter) handleAuthorizationReturn(c *gin.Context) {
 	for _, scope := range ar.GetRequestedScopes() {
 		ar.GrantScope(scope)
 	}
-	jwtSession, err := NewJWTSessionWithKey(a.externalURL, "user", a.privKey)
+
+	subject := "user"
+	session := sessions.Default(c)
+	if userID, ok := session.Get(auth.SessionKeyUserID).(string); ok && userID != "" {
+		subject = userID
+	}
+
+	jwtSession, err := NewJWTSessionWithKey(a.externalURL, subject, a.privKey)
 	if err != nil {
 		a.logger.With(utils.Err(err)...).Error("Failed to create JWT session", zap.Error(err))
 		a.provider.WriteAuthorizeError(ctx, c.Writer, ar, err)
@@ -190,6 +198,13 @@ func (a *IDPRouter) handleToken(c *gin.Context) {
 		a.logger.With(utils.Err(err)...).Error("Failed to create access request", zap.String("grant_type", c.PostForm("grant_type")))
 		a.provider.WriteAccessError(ctx, c.Writer, accessRequest, err)
 		return
+	}
+
+	// Propagate stored subject from DefaultSession to JWTClaims for JWT generation.
+	// The repository restores Subject into DefaultSession, but JWTClaims.Subject
+	// (used by fosite's JWT strategy) must be set separately.
+	if sub := session.GetSubject(); sub != "" && session.JWTClaims.Subject == "" {
+		session.JWTClaims.Subject = sub
 	}
 
 	response, err := a.provider.NewAccessResponse(ctx, accessRequest)

--- a/pkg/idp/idp_test.go
+++ b/pkg/idp/idp_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-contrib/sessions/cookie"
 	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/sigbit/mcp-auth-proxy/pkg/auth"
 	"github.com/sigbit/mcp-auth-proxy/pkg/repository"
 	"github.com/stretchr/testify/require"
@@ -377,6 +378,162 @@ func TestAuthWithoutState(t *testing.T) {
 	err = json.NewDecoder(tokenResp.Body).Decode(&tokenResult)
 	require.NoError(t, err)
 	require.NotEmpty(t, tokenResult["access_token"])
+}
+
+func setupTestServerWithUserID(t *testing.T, userID string) (*httptest.Server, repository.Repository, string) {
+	tmpDir, err := os.MkdirTemp("", "idp_test_*")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	repo, err := repository.NewKVSRepository(dbPath, "test")
+	require.NoError(t, err)
+	t.Cleanup(func() { repo.Close() })
+
+	secret := sha256.Sum256([]byte("test_secret"))
+
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	store := cookie.NewStore(secret[:])
+	router.Use(sessions.Sessions("test_session", store))
+
+	// Mock auth middleware that sets both authorized and user_id
+	router.Use(func(c *gin.Context) {
+		session := sessions.Default(c)
+		session.Set(auth.SessionKeyAuthorized, true)
+		session.Set(auth.SessionKeyUserID, userID)
+		err := session.Save()
+		if err != nil {
+			c.JSON(500, gin.H{"error": "Failed to save session"})
+			c.Abort()
+			return
+		}
+		c.Next()
+	})
+
+	authRouter, err := auth.NewAuthRouter([]string{}, false)
+	require.NoError(t, err)
+
+	logger, _ := zap.NewDevelopment()
+	idpRouter, err := NewIDPRouter(repo, privKey, logger, "http://localhost:8080", secret[:], authRouter)
+	require.NoError(t, err)
+
+	idpRouter.SetupRoutes(router)
+
+	server := httptest.NewServer(router)
+	t.Cleanup(server.Close)
+
+	return server, repo, tmpDir
+}
+
+func TestPrivateClient_JWTContainsUserIdentity(t *testing.T) {
+	server, _, _ := setupTestServerWithUserID(t, "jane@example.com")
+	regResp := registerTestClient(t, server.URL)
+
+	config := &oauth2.Config{
+		ClientID:     regResp.ClientID,
+		ClientSecret: regResp.ClientSecret,
+		RedirectURL:  "http://localhost:8080/callback",
+		Scopes:       []string{},
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  server.URL + AuthorizationEndpoint,
+			TokenURL: server.URL + TokenEndpoint,
+		},
+	}
+	state := "test-state"
+	authURL := config.AuthCodeURL(state, oauth2.AccessTypeOffline)
+
+	callbackURL := testAuthFlowWithURL(t, server.URL, authURL)
+
+	code := callbackURL.Query().Get("code")
+	tokenReq := url.Values{}
+	tokenReq.Set("grant_type", "authorization_code")
+	tokenReq.Set("code", code)
+	tokenReq.Set("redirect_uri", "http://localhost:8080/callback")
+	tokenReq.Set("client_id", regResp.ClientID)
+	tokenReq.Set("client_secret", regResp.ClientSecret)
+
+	tokenResp, err := http.PostForm(server.URL+TokenEndpoint, tokenReq)
+	require.NoError(t, err)
+	defer tokenResp.Body.Close()
+
+	require.Equal(t, http.StatusOK, tokenResp.StatusCode)
+
+	var tokenResult map[string]any
+	err = json.NewDecoder(tokenResp.Body).Decode(&tokenResult)
+	require.NoError(t, err)
+
+	accessToken, ok := tokenResult["access_token"].(string)
+	require.True(t, ok)
+	require.NotEmpty(t, accessToken)
+
+	// Parse JWT without verification to inspect claims
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	parsed, _, err := parser.ParseUnverified(accessToken, jwt.MapClaims{})
+	require.NoError(t, err)
+
+	claims, ok := parsed.Claims.(jwt.MapClaims)
+	require.True(t, ok)
+
+	sub, ok := claims["sub"].(string)
+	require.True(t, ok, "JWT should have a 'sub' claim")
+	require.Equal(t, "jane@example.com", sub, "JWT subject should contain the authenticated user's identity")
+}
+
+func TestPrivateClient_JWTFallsBackToDefaultSubject(t *testing.T) {
+	// setupTestServer does NOT set SessionKeyUserID, so subject should fall back to "user"
+	server, _, _ := setupTestServer(t)
+	regResp := registerTestClient(t, server.URL)
+
+	config := &oauth2.Config{
+		ClientID:     regResp.ClientID,
+		ClientSecret: regResp.ClientSecret,
+		RedirectURL:  "http://localhost:8080/callback",
+		Scopes:       []string{},
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  server.URL + AuthorizationEndpoint,
+			TokenURL: server.URL + TokenEndpoint,
+		},
+	}
+	authURL := config.AuthCodeURL("test-state", oauth2.AccessTypeOffline)
+
+	callbackURL := testAuthFlowWithURL(t, server.URL, authURL)
+
+	code := callbackURL.Query().Get("code")
+	tokenReq := url.Values{}
+	tokenReq.Set("grant_type", "authorization_code")
+	tokenReq.Set("code", code)
+	tokenReq.Set("redirect_uri", "http://localhost:8080/callback")
+	tokenReq.Set("client_id", regResp.ClientID)
+	tokenReq.Set("client_secret", regResp.ClientSecret)
+
+	tokenResp, err := http.PostForm(server.URL+TokenEndpoint, tokenReq)
+	require.NoError(t, err)
+	defer tokenResp.Body.Close()
+
+	require.Equal(t, http.StatusOK, tokenResp.StatusCode)
+
+	var tokenResult map[string]any
+	err = json.NewDecoder(tokenResp.Body).Decode(&tokenResult)
+	require.NoError(t, err)
+
+	accessToken, ok := tokenResult["access_token"].(string)
+	require.True(t, ok)
+
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	parsed, _, err := parser.ParseUnverified(accessToken, jwt.MapClaims{})
+	require.NoError(t, err)
+
+	claims, ok := parsed.Claims.(jwt.MapClaims)
+	require.True(t, ok)
+
+	sub, ok := claims["sub"].(string)
+	require.True(t, ok)
+	require.Equal(t, "user", sub, "JWT subject should fall back to 'user' when no user_id in session")
 }
 
 func TestAuthWithEmptyState(t *testing.T) {

--- a/pkg/mcp-proxy/main.go
+++ b/pkg/mcp-proxy/main.go
@@ -76,6 +76,7 @@ func Run(
 	proxyBearerToken string,
 	proxyTarget []string,
 	httpStreamingOnly bool,
+	passUserHeaders bool,
 ) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
@@ -292,7 +293,7 @@ func Run(
 	if err != nil {
 		return fmt.Errorf("failed to create IDP router: %w", err)
 	}
-	proxyRouter, err := newProxyRouter(externalURL, beHandler, &privKey.PublicKey, proxyHeadersMap, httpStreamingOnly)
+	proxyRouter, err := newProxyRouter(externalURL, beHandler, &privKey.PublicKey, proxyHeadersMap, httpStreamingOnly, passUserHeaders)
 	if err != nil {
 		return fmt.Errorf("failed to create proxy router: %w", err)
 	}

--- a/pkg/mcp-proxy/main_test.go
+++ b/pkg/mcp-proxy/main_test.go
@@ -31,7 +31,7 @@ func TestRun_NormalizesExternalURLTrailingSlash(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			var receivedURL string
-			newProxyRouter = func(externalURL string, proxyHandler http.Handler, publicKey *rsa.PublicKey, proxyHeaders http.Header, httpStreamingOnly bool) (*proxy.ProxyRouter, error) {
+			newProxyRouter = func(externalURL string, proxyHandler http.Handler, publicKey *rsa.PublicKey, proxyHeaders http.Header, httpStreamingOnly bool, passUserHeaders bool) (*proxy.ProxyRouter, error) {
 				receivedURL = externalURL
 				return nil, errors.New("stop early")
 			}
@@ -45,6 +45,7 @@ func TestRun_NormalizesExternalURLTrailingSlash(t *testing.T) {
 				"", "", "", nil, "", "", nil, nil, nil, nil,
 				false, "", "", nil, nil, "",
 				[]string{"http://example.com"}, false,
+				false,
 			)
 
 			if tt.wantErr {
@@ -67,7 +68,7 @@ func TestRun_PassesHTTPStreamingOnlyToProxyRouter(t *testing.T) {
 	})
 
 	var streamingOnlyReceived bool
-	newProxyRouter = func(externalURL string, proxyHandler http.Handler, publicKey *rsa.PublicKey, proxyHeaders http.Header, httpStreamingOnly bool) (*proxy.ProxyRouter, error) {
+	newProxyRouter = func(externalURL string, proxyHandler http.Handler, publicKey *rsa.PublicKey, proxyHeaders http.Header, httpStreamingOnly bool, passUserHeaders bool) (*proxy.ProxyRouter, error) {
 		streamingOnlyReceived = httpStreamingOnly
 		return nil, errors.New("proxy router init failed")
 	}
@@ -111,9 +112,69 @@ func TestRun_PassesHTTPStreamingOnlyToProxyRouter(t *testing.T) {
 		"",
 		[]string{"http://example.com"},
 		true,
+		false,
 	)
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to create proxy router")
 	require.True(t, streamingOnlyReceived, "httpStreamingOnly should be forwarded to proxy router")
+}
+
+func TestRun_PassesPassUserHeadersToProxyRouter(t *testing.T) {
+	originalNewProxyRouter := newProxyRouter
+	t.Cleanup(func() {
+		newProxyRouter = originalNewProxyRouter
+	})
+
+	var passUserHeadersReceived bool
+	newProxyRouter = func(externalURL string, proxyHandler http.Handler, publicKey *rsa.PublicKey, proxyHeaders http.Header, httpStreamingOnly bool, passUserHeaders bool) (*proxy.ProxyRouter, error) {
+		passUserHeadersReceived = passUserHeaders
+		return nil, errors.New("proxy router init failed")
+	}
+
+	err := Run(
+		":0",
+		":0",
+		false,
+		"",
+		"",
+		false,
+		"",
+		"",
+		t.TempDir(),
+		"local",
+		"",
+		"http://localhost",
+		"",
+		"",
+		nil,
+		nil,
+		"",
+		"",
+		nil,
+		nil,
+		"",
+		"",
+		"",
+		nil,
+		"",
+		"",
+		nil,
+		nil,
+		nil,
+		nil,
+		false,
+		"",
+		"",
+		nil,
+		nil,
+		"",
+		[]string{"http://example.com"},
+		false,
+		true,
+	)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to create proxy router")
+	require.True(t, passUserHeadersReceived, "passUserHeaders should be forwarded to proxy router")
 }

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -17,6 +17,7 @@ type Request struct {
 	RequestedAudience []string
 	GrantedAudience   []string
 	RotatedAt         time.Time
+	SessionSubject    string
 }
 
 type Client struct {
@@ -43,7 +44,7 @@ type AuthorizeRequest struct {
 
 func FromFositeReq(reqester fosite.Requester) *Request {
 	req := reqester.(*fosite.Request)
-	return &Request{
+	r := &Request{
 		ID:                req.ID,
 		RequestedAt:       req.RequestedAt,
 		Client:            FromFositeClient(req.Client),
@@ -53,6 +54,10 @@ func FromFositeReq(reqester fosite.Requester) *Request {
 		RequestedAudience: req.RequestedAudience,
 		GrantedAudience:   req.GrantedAudience,
 	}
+	if sess := req.GetSession(); sess != nil {
+		r.SessionSubject = sess.GetSubject()
+	}
+	return r
 }
 
 func (r *Request) ToFositeReq() *fosite.Request {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -16,6 +16,7 @@ type ProxyRouter struct {
 	publicKey         *rsa.PublicKey
 	proxyHeaders      http.Header
 	httpStreamingOnly bool
+	passUserHeaders   bool
 }
 
 func NewProxyRouter(
@@ -24,6 +25,7 @@ func NewProxyRouter(
 	publicKey *rsa.PublicKey,
 	proxyHeaders http.Header,
 	httpStreamingOnly bool,
+	passUserHeaders bool,
 ) (*ProxyRouter, error) {
 	return &ProxyRouter{
 		externalURL:       externalURL,
@@ -31,6 +33,7 @@ func NewProxyRouter(
 		publicKey:         publicKey,
 		proxyHeaders:      proxyHeaders,
 		httpStreamingOnly: httpStreamingOnly,
+		passUserHeaders:   passUserHeaders,
 	}, nil
 }
 
@@ -81,6 +84,15 @@ func (p *ProxyRouter) handleProxy(c *gin.Context) {
 	}
 
 	c.Request.Header.Del("Authorization")
+
+	if p.passUserHeaders {
+		if claims, ok := token.Claims.(jwt.MapClaims); ok {
+			if sub, ok := claims["sub"].(string); ok && sub != "" {
+				c.Request.Header.Set("X-Forwarded-User", sub)
+			}
+		}
+	}
+
 	for key, values := range p.proxyHeaders {
 		for _, value := range values {
 			c.Request.Header.Add(key, value)

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -70,7 +70,7 @@ func TestProxyRouter_HandleProxy_ValidToken(t *testing.T) {
 	proxyHeaders := make(http.Header)
 	proxyHeaders.Set("X-Forwarded-By", "mcp-auth-proxy")
 
-	proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, proxyHeaders, false)
+	proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, proxyHeaders, false, false)
 	require.NoError(t, err)
 
 	gin.SetMode(gin.TestMode)
@@ -108,7 +108,7 @@ func TestProxyRouter_ProtectedResourceTrailingSlash(t *testing.T) {
 	_, publicKey, err := generateRSAKeyPair()
 	require.NoError(t, err)
 
-	proxyRouter, err := NewProxyRouter("https://example.com/", http.NotFoundHandler(), publicKey, http.Header{}, false)
+	proxyRouter, err := NewProxyRouter("https://example.com/", http.NotFoundHandler(), publicKey, http.Header{}, false, false)
 	require.NoError(t, err)
 
 	gin.SetMode(gin.TestMode)
@@ -212,7 +212,7 @@ func TestProxyRouter_HTTPStreamingOnlyRejectsSSE(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, tt.streamingOnly)
+			proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, tt.streamingOnly, false)
 			require.NoError(t, err)
 
 			gin.SetMode(gin.TestMode)
@@ -236,6 +236,116 @@ func TestProxyRouter_HTTPStreamingOnlyRejectsSSE(t *testing.T) {
 
 			assert.Equal(t, tt.wantStatus, w.Code)
 			assert.Equal(t, tt.expectBackend, backendCalled, "backend call mismatch")
+		})
+	}
+}
+
+func TestProxyRouter_PassUserHeaders_NoSubClaim(t *testing.T) {
+	privateKey, publicKey, err := generateRSAKeyPair()
+	require.NoError(t, err)
+
+	var receivedHeader string
+	proxyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeader = r.Header.Get("X-Forwarded-User")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	proxyRouter, err := NewProxyRouter(
+		"https://example.com", proxyHandler, publicKey,
+		http.Header{}, false, true,
+	)
+	require.NoError(t, err)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	proxyRouter.SetupRoutes(router)
+
+	// JWT with no "sub" claim
+	token, err := createJWT(privateKey, jwt.MapClaims{
+		"exp": time.Now().Add(time.Hour).Unix(),
+		"iat": time.Now().Unix(),
+	})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("POST", "/mcp", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, receivedHeader, "X-Forwarded-User should not be set when JWT has no sub claim")
+}
+
+func TestProxyRouter_PassUserHeaders(t *testing.T) {
+	privateKey, publicKey, err := generateRSAKeyPair()
+	require.NoError(t, err)
+
+	cases := []struct {
+		name            string
+		passUserHeaders bool
+		jwtSubject      string
+		wantHeader      string
+	}{
+		{
+			name:            "enabled with subject",
+			passUserHeaders: true,
+			jwtSubject:      "jane@example.com",
+			wantHeader:      "jane@example.com",
+		},
+		{
+			name:            "disabled with subject",
+			passUserHeaders: false,
+			jwtSubject:      "jane@example.com",
+			wantHeader:      "",
+		},
+		{
+			name:            "enabled with legacy user subject",
+			passUserHeaders: true,
+			jwtSubject:      "user",
+			wantHeader:      "user",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var receivedHeader string
+			proxyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				receivedHeader = r.Header.Get("X-Forwarded-User")
+				w.WriteHeader(http.StatusOK)
+			})
+
+			proxyRouter, err := NewProxyRouter(
+				"https://example.com", proxyHandler, publicKey,
+				http.Header{}, false, tt.passUserHeaders,
+			)
+			require.NoError(t, err)
+
+			gin.SetMode(gin.TestMode)
+			router := gin.New()
+			proxyRouter.SetupRoutes(router)
+
+			token, err := createJWT(privateKey, jwt.MapClaims{
+				"sub": tt.jwtSubject,
+				"exp": time.Now().Add(time.Hour).Unix(),
+				"iat": time.Now().Unix(),
+			})
+			require.NoError(t, err)
+
+			req, err := http.NewRequest("POST", "/mcp", nil)
+			require.NoError(t, err)
+			req.Header.Set("Authorization", "Bearer "+token)
+
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			if tt.wantHeader != "" {
+				assert.Equal(t, tt.wantHeader, receivedHeader)
+			} else {
+				assert.Empty(t, receivedHeader)
+			}
 		})
 	}
 }

--- a/pkg/repository/kvs.go
+++ b/pkg/repository/kvs.go
@@ -19,6 +19,20 @@ type kvsRepository struct {
 
 var RefreshTokenGracePeriod = 1 * time.Hour
 
+// restoreSessionSubject sets the subject on a fosite session from stored data.
+// fosite.Session doesn't expose SetSubject, so we use an interface assertion.
+func restoreSessionSubject(sess fosite.Session, subject string) {
+	if subject == "" {
+		return
+	}
+	type subjectSetter interface {
+		SetSubject(string)
+	}
+	if setter, ok := sess.(subjectSetter); ok {
+		setter.SetSubject(subject)
+	}
+}
+
 func NewKVSRepository(path string, bucketName string) (Repository, error) {
 	db, err := bbolt.Open(path, 0600, nil)
 	if err != nil {
@@ -89,6 +103,7 @@ func (r *kvsRepository) GetAuthorizeCodeSession(ctx context.Context, code string
 		return nil, err
 	}
 	fositeReq := req.ToFositeReq()
+	restoreSessionSubject(sess, req.SessionSubject)
 	fositeReq.SetSession(sess)
 	return fositeReq, nil
 }
@@ -107,6 +122,7 @@ func (r *kvsRepository) GetAccessTokenSession(ctx context.Context, signature str
 		return nil, err
 	}
 	fositeReq := req.ToFositeReq()
+	restoreSessionSubject(sess, req.SessionSubject)
 	fositeReq.SetSession(sess)
 	return fositeReq, nil
 }
@@ -125,6 +141,7 @@ func (r *kvsRepository) GetRefreshTokenSession(ctx context.Context, signature st
 		return nil, err
 	}
 	fositeReq := req.ToFositeReq()
+	restoreSessionSubject(sess, req.SessionSubject)
 	fositeReq.SetSession(sess)
 	return fositeReq, nil
 }
@@ -200,6 +217,7 @@ func (r *kvsRepository) GetPKCERequestSession(ctx context.Context, signature str
 		return nil, err
 	}
 	fositeReq := req.ToFositeReq()
+	restoreSessionSubject(sess, req.SessionSubject)
 	fositeReq.SetSession(sess)
 	return fositeReq, nil
 }


### PR DESCRIPTION
## Summary

- Add `--pass-user-headers` flag (env: `PASS_USER_HEADERS`) that injects `X-Forwarded-User` header with the authenticated user's identity on proxied requests to the upstream server
- Fix JWT `sub` claim: was hardcoded as `"user"`, now contains the actual authenticated identity (OIDC user ID, email, or `password_user` for password auth)
- Fix session subject persistence: fosite's token storage round-trip was dropping the session subject, so the JWT never contained real identity

### What changed

| File | Change |
|------|--------|
| `pkg/auth/auth.go` | Store user identity in session (`SessionKeyUserID`) during OAuth callback and password login |
| `pkg/idp/idp.go` | Read identity from session for JWT subject; propagate subject to JWTClaims after token exchange |
| `pkg/models/models.go` | Add `SessionSubject` field to persist identity through fosite storage |
| `pkg/repository/kvs.go` | Restore session subject when loading stored sessions |
| `pkg/proxy/proxy.go` | Add `passUserHeaders` field; extract `sub` from JWT and set `X-Forwarded-User` |
| `main.go` | Wire `--pass-user-headers` CLI flag |
| `pkg/mcp-proxy/main.go` | Pass flag through to proxy router |

### How it works

1. User authenticates via OIDC/password → identity stored in session
2. IDP embeds identity as JWT `sub` claim (was hardcoded `"user"` before)
3. MCP client presents JWT → proxy validates, strips `Authorization`, sets `X-Forwarded-User: <sub>`
4. Upstream receives clean request with identity header

The flag defaults to `false` for backward compatibility.

## Test plan

- [x] Unit tests for all changed packages (`go test ./...` passes)
- [x] `TestPrivateClient_JWTContainsUserIdentity` — verifies JWT `sub` = real identity
- [x] `TestPrivateClient_JWTFallsBackToDefaultSubject` — verifies fallback to `"user"` for existing sessions
- [x] `TestPasswordLogin_StoresPasswordUserID` — verifies password login stores identity
- [x] `TestProxyRouter_PassUserHeaders` — verifies header injection (enabled/disabled/legacy)
- [x] `TestProxyRouter_PassUserHeaders_NoSubClaim` — verifies no header when JWT has no `sub`
- [x] `TestAuthenticationFlow_StoresUserID` — verifies OAuth flow stores identity in session
- [x] E2E test with curl: full OAuth flow → JWT with `sub: password_user` → backend receives `X-Forwarded-User: password_user`

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)