### PR TITLE
build: add Windows release artifacts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,12 @@ jobs:
           - name: mcp-auth-proxy-darwin-arm64
             os: darwin
             arch: arm64
+          - name: mcp-auth-proxy-windows-amd64.exe
+            os: windows
+            arch: amd64
+          - name: mcp-auth-proxy-windows-arm64.exe
+            os: windows
+            arch: arm64
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Add Windows release artifacts to the build workflow for amd64 and arm64.

## Type of Change

- [x] **build**: Changes that affect the build system or external dependencies

## Related Issues

<!-- Example: Closes #123 or Fixes #456. Leave blank if no related issues. -->
