### PR TITLE
feat: add HEADER_MAPPING_BASE flag to control JWT claims source for HEADER_MAPPING

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -176,11 +176,13 @@ openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048
 
 ### Proxy Options
 
-| Option                  | Environment Variable  | Default | Description                                                                                           |
-| ----------------------- | --------------------- | ------- | ----------------------------------------------------------------------------------------------------- |
-| `--proxy-bearer-token`  | `PROXY_BEARER_TOKEN`  | -       | Bearer token to add to Authorization header when proxying requests                                    |
-| `--proxy-headers`       | `PROXY_HEADERS`       | -       | Comma-separated list of headers to add when proxying requests (format: Header1:Value1,Header2:Value2) |
-| `--http-streaming-only` | `HTTP_STREAMING_ONLY` | `false` | Reject SSE (GET) requests and keep the backend operating in HTTP streaming-only mode                  |
-| `--trusted-proxies`     | `TRUSTED_PROXIES`     | -       | Comma-separated list of trusted proxies (IP addresses or CIDR ranges)                                 |
+| Option                  | Environment Variable  | Default     | Description                                                                                           |
+| ----------------------- | --------------------- | ----------- | ----------------------------------------------------------------------------------------------------- |
+| `--proxy-bearer-token`  | `PROXY_BEARER_TOKEN`  | -           | Bearer token to add to Authorization header when proxying requests                                    |
+| `--proxy-headers`       | `PROXY_HEADERS`       | -           | Comma-separated list of headers to add when proxying requests (format: Header1:Value1,Header2:Value2) |
+| `--header-mapping`      | `HEADER_MAPPING`      | -           | Comma-separated mapping of JSON pointer paths to header names (e.g., `/email:X-Forwarded-Email`)      |
+| `--header-mapping-base` | `HEADER_MAPPING_BASE` | `/userinfo` | JSON pointer base path for header mapping claims lookup (e.g., `/userinfo` or `/`)                    |
+| `--http-streaming-only` | `HTTP_STREAMING_ONLY` | `false`     | Reject SSE (GET) requests and keep the backend operating in HTTP streaming-only mode                  |
+| `--trusted-proxies`     | `TRUSTED_PROXIES`     | -           | Comma-separated list of trusted proxies (IP addresses or CIDR ranges)                                 |
 
 For practical configuration examples including environment variables, Docker Compose, and Kubernetes deployments, see the [Configuration Examples](./examples.md) page.

--- a/main.go
+++ b/main.go
@@ -155,6 +155,7 @@ type proxyRunnerFunc func(
 	proxyTarget []string,
 	httpStreamingOnly bool,
 	headerMapping map[string]string,
+	headerMappingBase string,
 ) error
 
 func main() {
@@ -200,6 +201,7 @@ func newRootCommand(run proxyRunnerFunc) *cobra.Command {
 	var proxyBearerToken string
 	var proxyHeaders string
 	var headerMapping string
+	var headerMappingBase string
 	var httpStreamingOnly bool
 	var trustedProxies string
 
@@ -323,6 +325,7 @@ func newRootCommand(run proxyRunnerFunc) *cobra.Command {
 				args,
 				httpStreamingOnly,
 				headerMappingMap,
+				headerMappingBase,
 			); err != nil {
 				panic(err)
 			}
@@ -376,7 +379,8 @@ func newRootCommand(run proxyRunnerFunc) *cobra.Command {
 	rootCmd.Flags().StringVar(&trustedProxies, "trusted-proxies", getEnvWithDefault("TRUSTED_PROXIES", ""), "Comma-separated list of trusted proxies (IP addresses or CIDR ranges)")
 	rootCmd.Flags().StringVar(&proxyHeaders, "proxy-headers", getEnvWithDefault("PROXY_HEADERS", ""), "Comma-separated list of headers to add when proxying requests (format: Header1:Value1,Header2:Value2)")
 	rootCmd.Flags().BoolVar(&httpStreamingOnly, "http-streaming-only", getEnvBoolWithDefault("HTTP_STREAMING_ONLY", false), "Reject SSE (GET) requests and keep the backend in HTTP streaming-only mode")
-	rootCmd.Flags().StringVar(&headerMapping, "header-mapping", getEnvWithDefault("HEADER_MAPPING", ""), "Comma-separated mapping of userinfo JSON pointer paths to header names (e.g., /email:X-Forwarded-Email,/preferred_username:X-Forwarded-User)")
+	rootCmd.Flags().StringVar(&headerMapping, "header-mapping", getEnvWithDefault("HEADER_MAPPING", ""), "Comma-separated mapping of JSON pointer paths to header names (e.g., /email:X-Forwarded-Email,/preferred_username:X-Forwarded-User)")
+	rootCmd.Flags().StringVar(&headerMappingBase, "header-mapping-base", getEnvWithDefault("HEADER_MAPPING_BASE", "/userinfo"), "JSON pointer base path for header mapping claims lookup (e.g., /userinfo or /)")
 
 	return rootCmd
 }

--- a/main_test.go
+++ b/main_test.go
@@ -403,6 +403,7 @@ func TestNewRootCommand_HTTPStreamingOnlyFlag(t *testing.T) {
 		proxyTarget []string,
 		httpStreamingOnly bool,
 		headerMapping map[string]string,
+		headerMappingBase string,
 	) error {
 		streamingOnly = httpStreamingOnly
 		receivedTargets = proxyTarget
@@ -467,6 +468,7 @@ func TestNewRootCommand_HTTPStreamingOnlyFromEnv(t *testing.T) {
 		proxyTarget []string,
 		httpStreamingOnly bool,
 		headerMapping map[string]string,
+		headerMappingBase string,
 	) error {
 		streamingOnly = httpStreamingOnly
 		return nil

--- a/pkg/mcp-proxy/main.go
+++ b/pkg/mcp-proxy/main.go
@@ -77,6 +77,7 @@ func Run(
 	proxyTarget []string,
 	httpStreamingOnly bool,
 	headerMapping map[string]string,
+	headerMappingBase string,
 ) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
@@ -293,7 +294,7 @@ func Run(
 	if err != nil {
 		return fmt.Errorf("failed to create IDP router: %w", err)
 	}
-	proxyRouter, err := newProxyRouter(externalURL, beHandler, &privKey.PublicKey, proxyHeadersMap, httpStreamingOnly, headerMapping)
+	proxyRouter, err := newProxyRouter(externalURL, beHandler, &privKey.PublicKey, proxyHeadersMap, httpStreamingOnly, headerMapping, headerMappingBase)
 	if err != nil {
 		return fmt.Errorf("failed to create proxy router: %w", err)
 	}

--- a/pkg/mcp-proxy/main_test.go
+++ b/pkg/mcp-proxy/main_test.go
@@ -34,7 +34,7 @@ func TestRun_NormalizesExternalURLTrailingSlash(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			var receivedURL string
-			newProxyRouter = func(externalURL string, proxyHandler http.Handler, publicKey *rsa.PublicKey, proxyHeaders http.Header, httpStreamingOnly bool, headerMapping map[string]string) (*proxy.ProxyRouter, error) {
+			newProxyRouter = func(externalURL string, proxyHandler http.Handler, publicKey *rsa.PublicKey, proxyHeaders http.Header, httpStreamingOnly bool, headerMapping map[string]string, headerMappingBase string) (*proxy.ProxyRouter, error) {
 				receivedURL = externalURL
 				return nil, errors.New("stop early")
 			}
@@ -47,7 +47,7 @@ func TestRun_NormalizesExternalURLTrailingSlash(t *testing.T) {
 				"", "", nil, nil,
 				"", "", "", nil, "", "", nil, nil, nil, nil,
 				false, "", "", nil, nil, "",
-				[]string{"http://example.com"}, false, nil,
+				[]string{"http://example.com"}, false, nil, "/userinfo",
 			)
 
 			if tt.wantErr {
@@ -70,7 +70,7 @@ func TestRun_PassesHTTPStreamingOnlyToProxyRouter(t *testing.T) {
 	})
 
 	var streamingOnlyReceived bool
-	newProxyRouter = func(externalURL string, proxyHandler http.Handler, publicKey *rsa.PublicKey, proxyHeaders http.Header, httpStreamingOnly bool, headerMapping map[string]string) (*proxy.ProxyRouter, error) {
+	newProxyRouter = func(externalURL string, proxyHandler http.Handler, publicKey *rsa.PublicKey, proxyHeaders http.Header, httpStreamingOnly bool, headerMapping map[string]string, headerMappingBase string) (*proxy.ProxyRouter, error) {
 		streamingOnlyReceived = httpStreamingOnly
 		return nil, errors.New("proxy router init failed")
 	}
@@ -115,6 +115,7 @@ func TestRun_PassesHTTPStreamingOnlyToProxyRouter(t *testing.T) {
 		[]string{"http://example.com"},
 		true,
 		nil,
+		"/userinfo",
 	)
 
 	require.Error(t, err)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -18,6 +18,7 @@ type ProxyRouter struct {
 	proxyHeaders      http.Header
 	httpStreamingOnly bool
 	headerMapping     map[string]string
+	headerMappingBase string
 }
 
 func NewProxyRouter(
@@ -27,6 +28,7 @@ func NewProxyRouter(
 	proxyHeaders http.Header,
 	httpStreamingOnly bool,
 	headerMapping map[string]string,
+	headerMappingBase string,
 ) (*ProxyRouter, error) {
 	return &ProxyRouter{
 		externalURL:       externalURL,
@@ -35,6 +37,7 @@ func NewProxyRouter(
 		proxyHeaders:      proxyHeaders,
 		httpStreamingOnly: httpStreamingOnly,
 		headerMapping:     headerMapping,
+		headerMappingBase: headerMappingBase,
 	}, nil
 }
 
@@ -93,30 +96,35 @@ func (p *ProxyRouter) handleProxy(c *gin.Context) {
 
 	if len(p.headerMapping) > 0 {
 		if claims, ok := token.Claims.(jwt.MapClaims); ok {
-			source := map[string]any(claims)
-			if userinfo, exists := claims["userinfo"]; exists {
-				if ui, ok := userinfo.(map[string]any); ok {
-					source = ui
+			var source any = map[string]any(claims)
+			if p.headerMappingBase != "/" {
+				val, err := jsonpointer.Get(source, p.headerMappingBase)
+				if err != nil {
+					source = nil
+				} else {
+					source = val
 				}
 			}
-			for pointer, headerName := range p.headerMapping {
-				val, err := jsonpointer.Get(source, pointer)
-				if err != nil {
-					continue
-				}
-				switch v := val.(type) {
-				case string:
-					c.Request.Header.Set(headerName, v)
-				case []any:
-					var parts []string
-					for _, item := range v {
-						if s, ok := item.(string); ok {
-							parts = append(parts, s)
-						}
+			if source != nil {
+				for pointer, headerName := range p.headerMapping {
+					val, err := jsonpointer.Get(source, pointer)
+					if err != nil {
+						continue
 					}
-					c.Request.Header.Set(headerName, strings.Join(parts, ","))
-				default:
-					c.Request.Header.Set(headerName, fmt.Sprintf("%v", v))
+					switch v := val.(type) {
+					case string:
+						c.Request.Header.Set(headerName, v)
+					case []any:
+						var parts []string
+						for _, item := range v {
+							if s, ok := item.(string); ok {
+								parts = append(parts, s)
+							}
+						}
+						c.Request.Header.Set(headerName, strings.Join(parts, ","))
+					default:
+						c.Request.Header.Set(headerName, fmt.Sprintf("%v", v))
+					}
 				}
 			}
 		}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -93,26 +93,30 @@ func (p *ProxyRouter) handleProxy(c *gin.Context) {
 
 	if len(p.headerMapping) > 0 {
 		if claims, ok := token.Claims.(jwt.MapClaims); ok {
+			source := map[string]any(claims)
 			if userinfo, exists := claims["userinfo"]; exists {
-				for pointer, headerName := range p.headerMapping {
-					val, err := jsonpointer.Get(userinfo, pointer)
-					if err != nil {
-						continue
-					}
-					switch v := val.(type) {
-					case string:
-						c.Request.Header.Set(headerName, v)
-					case []any:
-						var parts []string
-						for _, item := range v {
-							if s, ok := item.(string); ok {
-								parts = append(parts, s)
-							}
+				if ui, ok := userinfo.(map[string]any); ok {
+					source = ui
+				}
+			}
+			for pointer, headerName := range p.headerMapping {
+				val, err := jsonpointer.Get(source, pointer)
+				if err != nil {
+					continue
+				}
+				switch v := val.(type) {
+				case string:
+					c.Request.Header.Set(headerName, v)
+				case []any:
+					var parts []string
+					for _, item := range v {
+						if s, ok := item.(string); ok {
+							parts = append(parts, s)
 						}
-						c.Request.Header.Set(headerName, strings.Join(parts, ","))
-					default:
-						c.Request.Header.Set(headerName, fmt.Sprintf("%v", v))
 					}
+					c.Request.Header.Set(headerName, strings.Join(parts, ","))
+				default:
+					c.Request.Header.Set(headerName, fmt.Sprintf("%v", v))
 				}
 			}
 		}

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -197,6 +197,113 @@ func TestProxyRouter_HeaderMapping(t *testing.T) {
 	}
 }
 
+func TestProxyRouter_HeaderMapping_FallbackToTopLevelClaims(t *testing.T) {
+	privateKey, publicKey, err := generateRSAKeyPair()
+	require.NoError(t, err)
+
+	cases := []struct {
+		name            string
+		headerMapping   map[string]string
+		claims          jwt.MapClaims
+		expectedHeaders map[string]string
+		missingHeaders  []string
+	}{
+		{
+			name:          "top-level claim when userinfo is absent",
+			headerMapping: map[string]string{"/email": "X-Forwarded-Email"},
+			claims: jwt.MapClaims{
+				"sub":   "test-user",
+				"email": "user@example.com",
+				"exp":   time.Now().Add(time.Hour).Unix(),
+				"iat":   time.Now().Unix(),
+			},
+			expectedHeaders: map[string]string{
+				"X-Forwarded-Email": "user@example.com",
+			},
+		},
+		{
+			name:          "userinfo takes precedence over top-level claim",
+			headerMapping: map[string]string{"/email": "X-Forwarded-Email"},
+			claims: jwt.MapClaims{
+				"sub":      "test-user",
+				"email":    "toplevel@example.com",
+				"userinfo": map[string]any{"email": "userinfo@example.com"},
+				"exp":      time.Now().Add(time.Hour).Unix(),
+				"iat":      time.Now().Unix(),
+			},
+			expectedHeaders: map[string]string{
+				"X-Forwarded-Email": "userinfo@example.com",
+			},
+		},
+		{
+			name:          "multiple top-level claims without userinfo",
+			headerMapping: map[string]string{"/email": "X-Forwarded-Email", "/name": "X-Forwarded-Name"},
+			claims: jwt.MapClaims{
+				"sub":   "test-user",
+				"email": "user@example.com",
+				"name":  "John Doe",
+				"exp":   time.Now().Add(time.Hour).Unix(),
+				"iat":   time.Now().Unix(),
+			},
+			expectedHeaders: map[string]string{
+				"X-Forwarded-Email": "user@example.com",
+				"X-Forwarded-Name":  "John Doe",
+			},
+		},
+		{
+			name:          "missing claim in both userinfo and top-level",
+			headerMapping: map[string]string{"/email": "X-Forwarded-Email", "/missing": "X-Missing"},
+			claims: jwt.MapClaims{
+				"sub":   "test-user",
+				"email": "user@example.com",
+				"exp":   time.Now().Add(time.Hour).Unix(),
+				"iat":   time.Now().Unix(),
+			},
+			expectedHeaders: map[string]string{
+				"X-Forwarded-Email": "user@example.com",
+			},
+			missingHeaders: []string{"X-Missing"},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			receivedHeaders := http.Header{}
+			proxyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				for k, v := range r.Header {
+					receivedHeaders[k] = v
+				}
+				w.WriteHeader(http.StatusOK)
+			})
+
+			proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, false, tt.headerMapping)
+			require.NoError(t, err)
+
+			gin.SetMode(gin.TestMode)
+			router := gin.New()
+			proxyRouter.SetupRoutes(router)
+
+			token, err := createJWT(privateKey, tt.claims)
+			require.NoError(t, err)
+
+			req, err := http.NewRequest("GET", "/test", nil)
+			require.NoError(t, err)
+			req.Header.Set("Authorization", "Bearer "+token)
+
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			for header, expected := range tt.expectedHeaders {
+				assert.Equal(t, expected, receivedHeaders.Get(header), "header %s mismatch", header)
+			}
+			for _, header := range tt.missingHeaders {
+				assert.Empty(t, receivedHeaders.Get(header), "header %s should not be set", header)
+			}
+		})
+	}
+}
+
 func TestProxyRouter_ProtectedResourceTrailingSlash(t *testing.T) {
 	_, publicKey, err := generateRSAKeyPair()
 	require.NoError(t, err)

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -70,7 +70,7 @@ func TestProxyRouter_HandleProxy_ValidToken(t *testing.T) {
 	proxyHeaders := make(http.Header)
 	proxyHeaders.Set("X-Forwarded-By", "mcp-auth-proxy")
 
-	proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, proxyHeaders, false, nil)
+	proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, proxyHeaders, false, nil, "/userinfo")
 	require.NoError(t, err)
 
 	gin.SetMode(gin.TestMode)
@@ -163,7 +163,7 @@ func TestProxyRouter_HeaderMapping(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, false, tt.headerMapping)
+			proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, false, tt.headerMapping, "/userinfo")
 			require.NoError(t, err)
 
 			gin.SetMode(gin.TestMode)
@@ -197,20 +197,22 @@ func TestProxyRouter_HeaderMapping(t *testing.T) {
 	}
 }
 
-func TestProxyRouter_HeaderMapping_FallbackToTopLevelClaims(t *testing.T) {
+func TestProxyRouter_HeaderMappingBase(t *testing.T) {
 	privateKey, publicKey, err := generateRSAKeyPair()
 	require.NoError(t, err)
 
 	cases := []struct {
-		name            string
-		headerMapping   map[string]string
-		claims          jwt.MapClaims
-		expectedHeaders map[string]string
-		missingHeaders  []string
+		name              string
+		headerMapping     map[string]string
+		headerMappingBase string
+		claims            jwt.MapClaims
+		expectedHeaders   map[string]string
+		missingHeaders    []string
 	}{
 		{
-			name:          "top-level claim when userinfo is absent",
-			headerMapping: map[string]string{"/email": "X-Forwarded-Email"},
+			name:              "base=/ reads top-level claims",
+			headerMapping:     map[string]string{"/email": "X-Forwarded-Email"},
+			headerMappingBase: "/",
 			claims: jwt.MapClaims{
 				"sub":   "test-user",
 				"email": "user@example.com",
@@ -222,8 +224,9 @@ func TestProxyRouter_HeaderMapping_FallbackToTopLevelClaims(t *testing.T) {
 			},
 		},
 		{
-			name:          "userinfo takes precedence over top-level claim",
-			headerMapping: map[string]string{"/email": "X-Forwarded-Email"},
+			name:              "base=/userinfo reads userinfo claims",
+			headerMapping:     map[string]string{"/email": "X-Forwarded-Email"},
+			headerMappingBase: "/userinfo",
 			claims: jwt.MapClaims{
 				"sub":      "test-user",
 				"email":    "toplevel@example.com",
@@ -236,8 +239,9 @@ func TestProxyRouter_HeaderMapping_FallbackToTopLevelClaims(t *testing.T) {
 			},
 		},
 		{
-			name:          "multiple top-level claims without userinfo",
-			headerMapping: map[string]string{"/email": "X-Forwarded-Email", "/name": "X-Forwarded-Name"},
+			name:              "base=/ with multiple claims",
+			headerMapping:     map[string]string{"/email": "X-Forwarded-Email", "/name": "X-Forwarded-Name"},
+			headerMappingBase: "/",
 			claims: jwt.MapClaims{
 				"sub":   "test-user",
 				"email": "user@example.com",
@@ -251,8 +255,21 @@ func TestProxyRouter_HeaderMapping_FallbackToTopLevelClaims(t *testing.T) {
 			},
 		},
 		{
-			name:          "missing claim in both userinfo and top-level",
-			headerMapping: map[string]string{"/email": "X-Forwarded-Email", "/missing": "X-Missing"},
+			name:              "base=/userinfo skips when userinfo is absent",
+			headerMapping:     map[string]string{"/email": "X-Forwarded-Email"},
+			headerMappingBase: "/userinfo",
+			claims: jwt.MapClaims{
+				"sub":   "test-user",
+				"email": "user@example.com",
+				"exp":   time.Now().Add(time.Hour).Unix(),
+				"iat":   time.Now().Unix(),
+			},
+			missingHeaders: []string{"X-Forwarded-Email"},
+		},
+		{
+			name:              "base=/ missing claim is skipped",
+			headerMapping:     map[string]string{"/email": "X-Forwarded-Email", "/missing": "X-Missing"},
+			headerMappingBase: "/",
 			claims: jwt.MapClaims{
 				"sub":   "test-user",
 				"email": "user@example.com",
@@ -276,7 +293,7 @@ func TestProxyRouter_HeaderMapping_FallbackToTopLevelClaims(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, false, tt.headerMapping)
+			proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, false, tt.headerMapping, tt.headerMappingBase)
 			require.NoError(t, err)
 
 			gin.SetMode(gin.TestMode)
@@ -308,7 +325,7 @@ func TestProxyRouter_ProtectedResourceTrailingSlash(t *testing.T) {
 	_, publicKey, err := generateRSAKeyPair()
 	require.NoError(t, err)
 
-	proxyRouter, err := NewProxyRouter("https://example.com/", http.NotFoundHandler(), publicKey, http.Header{}, false, nil)
+	proxyRouter, err := NewProxyRouter("https://example.com/", http.NotFoundHandler(), publicKey, http.Header{}, false, nil, "/userinfo")
 	require.NoError(t, err)
 
 	gin.SetMode(gin.TestMode)
@@ -412,7 +429,7 @@ func TestProxyRouter_HTTPStreamingOnlyRejectsSSE(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, tt.streamingOnly, nil)
+			proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, tt.streamingOnly, nil, "/userinfo")
 			require.NoError(t, err)
 
 			gin.SetMode(gin.TestMode)


### PR DESCRIPTION
## Summary

- Add `--header-mapping-base` / `HEADER_MAPPING_BASE` flag (default: `/userinfo`) to explicitly control which JWT claims subtree `HEADER_MAPPING` reads from.
- Set to `/` to read from top-level JWT claims, which fixes header mapping for OIDC providers (e.g. Azure AD) that do not include a `userinfo` claim in the JWT.
- No implicit fallback — the base path is explicit and configurable.
- Added tests covering base `/`, `/userinfo`, and missing base scenarios.
- Added documentation for both `--header-mapping` and `--header-mapping-base` in the configuration reference.

## Type of Change

- [x] **feat**: A new feature

## Related Issues

Closes #143