### PR TITLE
Add forwardAuthorization flag for conditional token forwarding

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -176,14 +176,14 @@ openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048
 
 ### Proxy Options
 
-| Option                  | Environment Variable  | Default     | Description                                                                                           |
-| ----------------------- | --------------------- | ----------- | ----------------------------------------------------------------------------------------------------- |
-| `--proxy-bearer-token`        | `PROXY_BEARER_TOKEN`        | -           | Bearer token to add to Authorization header when proxying requests                                     |
-| `--proxy-forward-authorization` | `PROXY_FORWARD_AUTHORIZATION` | `false`     | Forward the incoming Authorization bearer token to the backend after validation                         |
-| `--proxy-headers`             | `PROXY_HEADERS`             | -           | Comma-separated list of headers to add when proxying requests (format: Header1:Value1,Header2:Value2)  |
-| `--header-mapping`      | `HEADER_MAPPING`      | -           | Comma-separated mapping of JSON pointer paths to header names (e.g., `/email:X-Forwarded-Email`)      |
-| `--header-mapping-base` | `HEADER_MAPPING_BASE` | `/userinfo` | JSON pointer base path for header mapping claims lookup (e.g., `/userinfo` or `/`)                    |
-| `--http-streaming-only` | `HTTP_STREAMING_ONLY` | `false`     | Reject SSE (GET) requests and keep the backend operating in HTTP streaming-only mode                  |
-| `--trusted-proxies`     | `TRUSTED_PROXIES`     | -           | Comma-separated list of trusted proxies (IP addresses or CIDR ranges)                                 |
+| Option                          | Environment Variable          | Default     | Description                                                                                           |
+| ------------------------------- | ----------------------------- | ----------- | ----------------------------------------------------------------------------------------------------- |
+| `--proxy-bearer-token`          | `PROXY_BEARER_TOKEN`          | -           | Bearer token to add to Authorization header when proxying requests                                    |
+| `--proxy-forward-authorization` | `PROXY_FORWARD_AUTHORIZATION` | `false`     | Forward the incoming Authorization bearer token to the backend after validation                       |
+| `--proxy-headers`               | `PROXY_HEADERS`               | -           | Comma-separated list of headers to add when proxying requests (format: Header1:Value1,Header2:Value2) |
+| `--header-mapping`              | `HEADER_MAPPING`              | -           | Comma-separated mapping of JSON pointer paths to header names (e.g., `/email:X-Forwarded-Email`)      |
+| `--header-mapping-base`         | `HEADER_MAPPING_BASE`         | `/userinfo` | JSON pointer base path for header mapping claims lookup (e.g., `/userinfo` or `/`)                    |
+| `--http-streaming-only`         | `HTTP_STREAMING_ONLY`         | `false`     | Reject SSE (GET) requests and keep the backend operating in HTTP streaming-only mode                  |
+| `--trusted-proxies`             | `TRUSTED_PROXIES`             | -           | Comma-separated list of trusted proxies (IP addresses or CIDR ranges)                                 |
 
 For practical configuration examples including environment variables, Docker Compose, and Kubernetes deployments, see the [Configuration Examples](./examples.md) page.

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -178,8 +178,9 @@ openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048
 
 | Option                  | Environment Variable  | Default     | Description                                                                                           |
 | ----------------------- | --------------------- | ----------- | ----------------------------------------------------------------------------------------------------- |
-| `--proxy-bearer-token`  | `PROXY_BEARER_TOKEN`  | -           | Bearer token to add to Authorization header when proxying requests                                    |
-| `--proxy-headers`       | `PROXY_HEADERS`       | -           | Comma-separated list of headers to add when proxying requests (format: Header1:Value1,Header2:Value2) |
+| `--proxy-bearer-token`        | `PROXY_BEARER_TOKEN`        | -           | Bearer token to add to Authorization header when proxying requests                                     |
+| `--proxy-forward-authorization` | `PROXY_FORWARD_AUTHORIZATION` | `false`     | Forward the incoming Authorization bearer token to the backend after validation                         |
+| `--proxy-headers`             | `PROXY_HEADERS`             | -           | Comma-separated list of headers to add when proxying requests (format: Header1:Value1,Header2:Value2)  |
 | `--header-mapping`      | `HEADER_MAPPING`      | -           | Comma-separated mapping of JSON pointer paths to header names (e.g., `/email:X-Forwarded-Email`)      |
 | `--header-mapping-base` | `HEADER_MAPPING_BASE` | `/userinfo` | JSON pointer base path for header mapping claims lookup (e.g., `/userinfo` or `/`)                    |
 | `--http-streaming-only` | `HTTP_STREAMING_ONLY` | `false`     | Reject SSE (GET) requests and keep the backend operating in HTTP streaming-only mode                  |

--- a/main.go
+++ b/main.go
@@ -152,6 +152,7 @@ type proxyRunnerFunc func(
 	trustedProxy []string,
 	proxyHeaders []string,
 	proxyBearerToken string,
+	forwardAuthorizationHeader bool,
 	proxyTarget []string,
 	httpStreamingOnly bool,
 	headerMapping map[string]string,
@@ -199,6 +200,7 @@ func newRootCommand(run proxyRunnerFunc) *cobra.Command {
 	var password string
 	var passwordHash string
 	var proxyBearerToken string
+	var forwardAuthorizationHeader bool
 	var proxyHeaders string
 	var headerMapping string
 	var headerMappingBase string
@@ -322,6 +324,7 @@ func newRootCommand(run proxyRunnerFunc) *cobra.Command {
 				trustedProxiesList,
 				proxyHeadersList,
 				proxyBearerToken,
+				forwardAuthorizationHeader,
 				args,
 				httpStreamingOnly,
 				headerMappingMap,
@@ -376,6 +379,7 @@ func newRootCommand(run proxyRunnerFunc) *cobra.Command {
 
 	// Proxy headers configuration
 	rootCmd.Flags().StringVar(&proxyBearerToken, "proxy-bearer-token", getEnvWithDefault("PROXY_BEARER_TOKEN", ""), "Bearer token to add to Authorization header when proxying requests")
+	rootCmd.Flags().BoolVar(&forwardAuthorizationHeader, "proxy-forward-authorization", getEnvBoolWithDefault("PROXY_FORWARD_AUTHORIZATION", false), "Forward the incoming Authorization bearer token to the backend after validation")
 	rootCmd.Flags().StringVar(&trustedProxies, "trusted-proxies", getEnvWithDefault("TRUSTED_PROXIES", ""), "Comma-separated list of trusted proxies (IP addresses or CIDR ranges)")
 	rootCmd.Flags().StringVar(&proxyHeaders, "proxy-headers", getEnvWithDefault("PROXY_HEADERS", ""), "Comma-separated list of headers to add when proxying requests (format: Header1:Value1,Header2:Value2)")
 	rootCmd.Flags().BoolVar(&httpStreamingOnly, "http-streaming-only", getEnvBoolWithDefault("HTTP_STREAMING_ONLY", false), "Reject SSE (GET) requests and keep the backend in HTTP streaming-only mode")

--- a/main_test.go
+++ b/main_test.go
@@ -400,6 +400,7 @@ func TestNewRootCommand_HTTPStreamingOnlyFlag(t *testing.T) {
 		trustedProxy []string,
 		proxyHeaders []string,
 		proxyBearerToken string,
+		forwardAuthorizationHeader bool,
 		proxyTarget []string,
 		httpStreamingOnly bool,
 		headerMapping map[string]string,
@@ -465,6 +466,7 @@ func TestNewRootCommand_HTTPStreamingOnlyFromEnv(t *testing.T) {
 		trustedProxy []string,
 		proxyHeaders []string,
 		proxyBearerToken string,
+		forwardAuthorizationHeader bool,
 		proxyTarget []string,
 		httpStreamingOnly bool,
 		headerMapping map[string]string,
@@ -483,5 +485,67 @@ func TestNewRootCommand_HTTPStreamingOnlyFromEnv(t *testing.T) {
 
 	if !streamingOnly {
 		t.Fatalf("expected httpStreamingOnly to default to true from env var")
+	}
+}
+
+func TestNewRootCommand_ForwardAuthorizationFlag(t *testing.T) {
+	t.Setenv("PROXY_FORWARD_AUTHORIZATION", "")
+
+	var forwardAuthorization bool
+	runner := proxyRunnerFunc(func(listen string,
+		tlsListen string,
+		autoTLS bool,
+		tlsHost string,
+		tlsDirectoryURL string,
+		tlsAcceptTOS bool,
+		tlsCertFile string,
+		tlsKeyFile string,
+		dataPath string,
+		repositoryBackend string,
+		repositoryDSN string,
+		externalURL string,
+		googleClientID string,
+		googleClientSecret string,
+		googleAllowedUsers []string,
+		googleAllowedWorkspaces []string,
+		githubClientID string,
+		githubClientSecret string,
+		githubAllowedUsers []string,
+		githubAllowedOrgs []string,
+		oidcConfigurationURL string,
+		oidcClientID string,
+		oidcClientSecret string,
+		oidcScopes []string,
+		oidcUserIDField string,
+		oidcProviderName string,
+		oidcAllowedUsers []string,
+		oidcAllowedUsersGlob []string,
+		oidcAllowedAttributes map[string][]string,
+		oidcAllowedAttributesGlob map[string][]string,
+		noProviderAutoSelect bool,
+		password string,
+		passwordHash string,
+		trustedProxy []string,
+		proxyHeaders []string,
+		proxyBearerToken string,
+		forwardAuthorizationHeader bool,
+		proxyTarget []string,
+		httpStreamingOnly bool,
+		headerMapping map[string]string,
+		headerMappingBase string,
+	) error {
+		forwardAuthorization = forwardAuthorizationHeader
+		return nil
+	})
+
+	cmd := newRootCommand(runner)
+	cmd.SetArgs([]string{"--proxy-forward-authorization", "http://backend"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected command to succeed, got error: %v", err)
+	}
+
+	if !forwardAuthorization {
+		t.Fatalf("expected forwardAuthorizationHeader to be true when flag is set")
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -549,3 +549,65 @@ func TestNewRootCommand_ForwardAuthorizationFlag(t *testing.T) {
 		t.Fatalf("expected forwardAuthorizationHeader to be true when flag is set")
 	}
 }
+
+func TestNewRootCommand_ForwardAuthorizationFromEnv(t *testing.T) {
+	t.Setenv("PROXY_FORWARD_AUTHORIZATION", "true")
+
+	var forwardAuthorization bool
+	runner := proxyRunnerFunc(func(listen string,
+		tlsListen string,
+		autoTLS bool,
+		tlsHost string,
+		tlsDirectoryURL string,
+		tlsAcceptTOS bool,
+		tlsCertFile string,
+		tlsKeyFile string,
+		dataPath string,
+		repositoryBackend string,
+		repositoryDSN string,
+		externalURL string,
+		googleClientID string,
+		googleClientSecret string,
+		googleAllowedUsers []string,
+		googleAllowedWorkspaces []string,
+		githubClientID string,
+		githubClientSecret string,
+		githubAllowedUsers []string,
+		githubAllowedOrgs []string,
+		oidcConfigurationURL string,
+		oidcClientID string,
+		oidcClientSecret string,
+		oidcScopes []string,
+		oidcUserIDField string,
+		oidcProviderName string,
+		oidcAllowedUsers []string,
+		oidcAllowedUsersGlob []string,
+		oidcAllowedAttributes map[string][]string,
+		oidcAllowedAttributesGlob map[string][]string,
+		noProviderAutoSelect bool,
+		password string,
+		passwordHash string,
+		trustedProxy []string,
+		proxyHeaders []string,
+		proxyBearerToken string,
+		forwardAuthorizationHeader bool,
+		proxyTarget []string,
+		httpStreamingOnly bool,
+		headerMapping map[string]string,
+		headerMappingBase string,
+	) error {
+		forwardAuthorization = forwardAuthorizationHeader
+		return nil
+	})
+
+	cmd := newRootCommand(runner)
+	cmd.SetArgs([]string{"http://backend"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected command to succeed, got error: %v", err)
+	}
+
+	if !forwardAuthorization {
+		t.Fatalf("expected forwardAuthorizationHeader to default to true from env var")
+	}
+}

--- a/pkg/mcp-proxy/main.go
+++ b/pkg/mcp-proxy/main.go
@@ -74,6 +74,7 @@ func Run(
 	trustedProxy []string,
 	proxyHeaders []string,
 	proxyBearerToken string,
+	forwardAuthorizationHeader bool,
 	proxyTarget []string,
 	httpStreamingOnly bool,
 	headerMapping map[string]string,
@@ -298,7 +299,7 @@ func Run(
 	if err != nil {
 		return fmt.Errorf("failed to create IDP router: %w", err)
 	}
-	proxyRouter, err := newProxyRouter(externalURL, beHandler, &privKey.PublicKey, proxyHeadersMap, httpStreamingOnly, headerMapping, headerMappingBase)
+	proxyRouter, err := newProxyRouter(externalURL, beHandler, &privKey.PublicKey, proxyHeadersMap, httpStreamingOnly, forwardAuthorizationHeader, headerMapping, headerMappingBase)
 	if err != nil {
 		return fmt.Errorf("failed to create proxy router: %w", err)
 	}

--- a/pkg/mcp-proxy/main_test.go
+++ b/pkg/mcp-proxy/main_test.go
@@ -34,7 +34,7 @@ func TestRun_NormalizesExternalURLTrailingSlash(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			var receivedURL string
-			newProxyRouter = func(externalURL string, proxyHandler http.Handler, publicKey *rsa.PublicKey, proxyHeaders http.Header, httpStreamingOnly bool, headerMapping map[string]string, headerMappingBase string) (*proxy.ProxyRouter, error) {
+			newProxyRouter = func(externalURL string, proxyHandler http.Handler, publicKey *rsa.PublicKey, proxyHeaders http.Header, httpStreamingOnly bool, forwardAuthorizationHeader bool, headerMapping map[string]string, headerMappingBase string) (*proxy.ProxyRouter, error) {
 				receivedURL = externalURL
 				return nil, errors.New("stop early")
 			}
@@ -46,7 +46,7 @@ func TestRun_NormalizesExternalURLTrailingSlash(t *testing.T) {
 				"", "", nil, nil,
 				"", "", nil, nil,
 				"", "", "", nil, "", "", nil, nil, nil, nil,
-				false, "", "", nil, nil, "",
+				false, "", "", nil, nil, "", false,
 				[]string{"http://example.com"}, false, nil, "/userinfo",
 			)
 
@@ -70,7 +70,7 @@ func TestRun_PassesHTTPStreamingOnlyToProxyRouter(t *testing.T) {
 	})
 
 	var streamingOnlyReceived bool
-	newProxyRouter = func(externalURL string, proxyHandler http.Handler, publicKey *rsa.PublicKey, proxyHeaders http.Header, httpStreamingOnly bool, headerMapping map[string]string, headerMappingBase string) (*proxy.ProxyRouter, error) {
+	newProxyRouter = func(externalURL string, proxyHandler http.Handler, publicKey *rsa.PublicKey, proxyHeaders http.Header, httpStreamingOnly bool, forwardAuthorizationHeader bool, headerMapping map[string]string, headerMappingBase string) (*proxy.ProxyRouter, error) {
 		streamingOnlyReceived = httpStreamingOnly
 		return nil, errors.New("proxy router init failed")
 	}
@@ -112,6 +112,7 @@ func TestRun_PassesHTTPStreamingOnlyToProxyRouter(t *testing.T) {
 		nil,
 		nil,
 		"",
+		false,
 		[]string{"http://example.com"},
 		true,
 		nil,

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -12,13 +12,14 @@ import (
 )
 
 type ProxyRouter struct {
-	externalURL       string
-	proxy             http.Handler
-	publicKey         *rsa.PublicKey
-	proxyHeaders      http.Header
-	httpStreamingOnly bool
-	headerMapping     map[string]string
-	headerMappingBase string
+	externalURL                string
+	proxy                      http.Handler
+	publicKey                  *rsa.PublicKey
+	proxyHeaders               http.Header
+	httpStreamingOnly          bool
+	forwardAuthorizationHeader bool
+	headerMapping              map[string]string
+	headerMappingBase          string
 }
 
 func NewProxyRouter(
@@ -27,17 +28,19 @@ func NewProxyRouter(
 	publicKey *rsa.PublicKey,
 	proxyHeaders http.Header,
 	httpStreamingOnly bool,
+	forwardAuthorizationHeader bool,
 	headerMapping map[string]string,
 	headerMappingBase string,
 ) (*ProxyRouter, error) {
 	return &ProxyRouter{
-		externalURL:       externalURL,
-		proxy:             proxy,
-		publicKey:         publicKey,
-		proxyHeaders:      proxyHeaders,
-		httpStreamingOnly: httpStreamingOnly,
-		headerMapping:     headerMapping,
-		headerMappingBase: headerMappingBase,
+		externalURL:                externalURL,
+		proxy:                      proxy,
+		publicKey:                  publicKey,
+		proxyHeaders:               proxyHeaders,
+		httpStreamingOnly:          httpStreamingOnly,
+		forwardAuthorizationHeader: forwardAuthorizationHeader,
+		headerMapping:              headerMapping,
+		headerMappingBase:          headerMappingBase,
 	}, nil
 }
 
@@ -87,8 +90,13 @@ func (p *ProxyRouter) handleProxy(c *gin.Context) {
 		return
 	}
 
-	c.Request.Header.Del("Authorization")
+	if !p.forwardAuthorizationHeader {
+		c.Request.Header.Del("Authorization")
+	}
 	for key, values := range p.proxyHeaders {
+		if strings.EqualFold(key, "Authorization") {
+			c.Request.Header.Del("Authorization")
+		}
 		for _, value := range values {
 			c.Request.Header.Add(key, value)
 		}

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -70,7 +70,7 @@ func TestProxyRouter_HandleProxy_ValidToken(t *testing.T) {
 	proxyHeaders := make(http.Header)
 	proxyHeaders.Set("X-Forwarded-By", "mcp-auth-proxy")
 
-	proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, proxyHeaders, false, nil, "/userinfo")
+	proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, proxyHeaders, false, false, nil, "/userinfo")
 	require.NoError(t, err)
 
 	gin.SetMode(gin.TestMode)
@@ -163,7 +163,7 @@ func TestProxyRouter_HeaderMapping(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, false, tt.headerMapping, "/userinfo")
+			proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, false, false, tt.headerMapping, "/userinfo")
 			require.NoError(t, err)
 
 			gin.SetMode(gin.TestMode)
@@ -293,7 +293,7 @@ func TestProxyRouter_HeaderMappingBase(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, false, tt.headerMapping, tt.headerMappingBase)
+			proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, false, false, tt.headerMapping, tt.headerMappingBase)
 			require.NoError(t, err)
 
 			gin.SetMode(gin.TestMode)
@@ -321,11 +321,80 @@ func TestProxyRouter_HeaderMappingBase(t *testing.T) {
 	}
 }
 
+func TestProxyRouter_AuthorizationHeaderDefaultBehavior(t *testing.T) {
+	privateKey, publicKey, err := generateRSAKeyPair()
+	require.NoError(t, err)
+
+	t.Run("strips authorization header by default", func(t *testing.T) {
+		var backendAuthorization string
+		proxyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			backendAuthorization = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusOK)
+		})
+
+		proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, false, false, nil, "/userinfo")
+		require.NoError(t, err)
+
+		gin.SetMode(gin.TestMode)
+		router := gin.New()
+		proxyRouter.SetupRoutes(router)
+
+		token, err := createJWT(privateKey, jwt.MapClaims{
+			"sub": "user",
+			"exp": time.Now().Add(time.Hour).Unix(),
+			"iat": time.Now().Unix(),
+		})
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodGet, "/mcp", nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Empty(t, backendAuthorization)
+	})
+
+	t.Run("forwards authorization header when enabled", func(t *testing.T) {
+		var backendAuthorization string
+		proxyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			backendAuthorization = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusOK)
+		})
+
+		proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, false, true, nil, "/userinfo")
+		require.NoError(t, err)
+
+		gin.SetMode(gin.TestMode)
+		router := gin.New()
+		proxyRouter.SetupRoutes(router)
+
+		token, err := createJWT(privateKey, jwt.MapClaims{
+			"sub": "user",
+			"exp": time.Now().Add(time.Hour).Unix(),
+			"iat": time.Now().Unix(),
+		})
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodGet, "/mcp", nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "Bearer "+token, backendAuthorization)
+	})
+}
+
 func TestProxyRouter_ProtectedResourceTrailingSlash(t *testing.T) {
 	_, publicKey, err := generateRSAKeyPair()
 	require.NoError(t, err)
 
-	proxyRouter, err := NewProxyRouter("https://example.com/", http.NotFoundHandler(), publicKey, http.Header{}, false, nil, "/userinfo")
+	proxyRouter, err := NewProxyRouter("https://example.com/", http.NotFoundHandler(), publicKey, http.Header{}, false, false, nil, "/userinfo")
 	require.NoError(t, err)
 
 	gin.SetMode(gin.TestMode)
@@ -429,7 +498,7 @@ func TestProxyRouter_HTTPStreamingOnlyRejectsSSE(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, tt.streamingOnly, nil, "/userinfo")
+			proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, tt.streamingOnly, false, nil, "/userinfo")
 			require.NoError(t, err)
 
 			gin.SetMode(gin.TestMode)


### PR DESCRIPTION
Introduce a new configuration option to control whether the incoming Authorization bearer token is forwarded to the backend after validation. By default, the proxy strips the Authorization header before forwarding requests, but with the new `--proxy-forward-authorization` flag (or `PROXY_FORWARD_AUTHORIZATION` environment variable), this behavior can be changed. The implementation includes updates to the CLI, configuration, proxy logic, and comprehensive tests to cover the new functionality.

**New Authorization Forwarding Feature:**

* Added the `--proxy-forward-authorization` CLI flag and `PROXY_FORWARD_AUTHORIZATION` environment variable, allowing users to forward the incoming Authorization bearer token to the backend after validation. This is documented in `configuration.md` and wired into the CLI and environment variable parsing. [[1]](diffhunk://#diff-26a27f31b938efc2e2e661c3ee8a5b46ea02efaf7a89e9d38d892878da24e29dR182) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R203) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R382)

* Updated the proxy runner, main logic, and proxy router to accept and propagate the new `forwardAuthorizationHeader` boolean parameter throughout the application. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R155) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R327) [[3]](diffhunk://#diff-6bc2f5afdcbe24dac926df49bce9a8fb2e5e4c98ed66fec76238e6a9b45404f3R77) [[4]](diffhunk://#diff-6bc2f5afdcbe24dac926df49bce9a8fb2e5e4c98ed66fec76238e6a9b45404f3L301-R302) [[5]](diffhunk://#diff-b41d02f71c670ff801d99892d32ef6dd36e43fcdf4c12c044cd34a073cc18200R20) [[6]](diffhunk://#diff-b41d02f71c670ff801d99892d32ef6dd36e43fcdf4c12c044cd34a073cc18200R31) [[7]](diffhunk://#diff-b41d02f71c670ff801d99892d32ef6dd36e43fcdf4c12c044cd34a073cc18200R41)

**Proxy Logic Changes:**

* Modified the proxy handler so that, by default, the Authorization header is stripped before forwarding requests. If the new flag is enabled, the header is preserved and forwarded to the backend.

**Testing Enhancements:**

* Added and updated tests to verify the new behavior, including a dedicated test to ensure the Authorization header is stripped by default and forwarded when the flag is set. Tests were also updated to pass the new parameter to the proxy router where needed. [[1]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eR403) [[2]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eR469) [[3]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eR490-R551) [[4]](diffhunk://#diff-41ac6f84c8e979d741aa5693c53da94f155d83ef93c5761d3899609971bfe375L73-R73) [[5]](diffhunk://#diff-41ac6f84c8e979d741aa5693c53da94f155d83ef93c5761d3899609971bfe375L166-R166) [[6]](diffhunk://#diff-41ac6f84c8e979d741aa5693c53da94f155d83ef93c5761d3899609971bfe375L296-R296) [[7]](diffhunk://#diff-41ac6f84c8e979d741aa5693c53da94f155d83ef93c5761d3899609971bfe375R324-R397) [[8]](diffhunk://#diff-41ac6f84c8e979d741aa5693c53da94f155d83ef93c5761d3899609971bfe375L432-R501)

These changes provide users with more control over how authentication information is handled when proxying requests, improving flexibility and security.- Introduced `--proxy-forward-authorization` command line option.
- Updated configuration documentation to include new option.
- Modified proxy handling to conditionally forward the Authorization header based on the new flag.
- Added tests to verify the behavior of the new flag.

## Summary

Now possible to pass JWT token towards backend servers for identity mapping via Authorization header.

## Type of Change

- [x ] **feat**: A new feature
- [ ] **fix**: A bug fix
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] **refactor**: A code change that neither fixes a bug nor adds a feature
- [ ] **perf**: A code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to our CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit

