### PR TITLE
ci: clarify docs formatting check

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -51,5 +51,5 @@ jobs:
       - name: Install docs dependencies
         run: npm ci
 
-      - name: Lint documentation
-        run: npm run lint
+      - name: Check docs formatting
+        run: npm run format:check

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,9 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
-    "lint": "prettier . --check"
+    "format": "prettier . --write",
+    "format:check": "prettier . --check",
+    "lint": "npm run format:check"
   },
   "dependencies": {
     "@docusaurus/core": "3.8.1",


### PR DESCRIPTION
## Summary

- Add a docs `format` script for applying Prettier locally
- Split docs format checking into `format:check` and make CI call it directly
- Rename the CI step so formatting failures are not presented as generic docs lint failures

## Type of Change

- [ ] **feat**: A new feature
- [ ] **fix**: A bug fix
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] **refactor**: A code change that neither fixes a bug nor adds a feature
- [ ] **perf**: A code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [x] **ci**: Changes to our CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit

## Related Issues