### PR TITLE
refactor: simplify CLI parsing and OIDC errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,12 +17,20 @@ func getEnvWithDefault(key, defaultValue string) string {
 
 func getEnvBoolWithDefault(key string, defaultValue bool) bool {
 	if value := os.Getenv(key); value != "" {
-		if strings.ToLower(value) == "true" || value == "1" {
-			return true
-		}
-		return false
+		return strings.EqualFold(value, "true") || value == "1"
 	}
 	return defaultValue
+}
+
+func splitCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	return parts
 }
 
 // splitWithEscapes splits a string by delimiter, respecting escape sequences
@@ -214,45 +222,11 @@ func newRootCommand(run proxyRunnerFunc) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use: "mcp-warp",
 		Run: func(cmd *cobra.Command, args []string) {
-			var googleAllowedUsersList []string
-			if googleAllowedUsers != "" {
-				googleAllowedUsersList = strings.Split(googleAllowedUsers, ",")
-				for i := range googleAllowedUsersList {
-					googleAllowedUsersList[i] = strings.TrimSpace(googleAllowedUsersList[i])
-				}
-			}
-
-			var googleAllowedWorkspacesList []string
-			if googleAllowedWorkspaces != "" {
-				googleAllowedWorkspacesList = strings.Split(googleAllowedWorkspaces, ",")
-				for i := range googleAllowedWorkspacesList {
-					googleAllowedWorkspacesList[i] = strings.TrimSpace(googleAllowedWorkspacesList[i])
-				}
-			}
-
-			var githubAllowedUsersList []string
-			if githubAllowedUsers != "" {
-				githubAllowedUsersList = strings.Split(githubAllowedUsers, ",")
-				for i := range githubAllowedUsersList {
-					githubAllowedUsersList[i] = strings.TrimSpace(githubAllowedUsersList[i])
-				}
-			}
-
-			var githubAllowedOrgsList []string
-			if githubAllowedOrgs != "" {
-				githubAllowedOrgsList = strings.Split(githubAllowedOrgs, ",")
-				for i := range githubAllowedOrgsList {
-					githubAllowedOrgsList[i] = strings.TrimSpace(githubAllowedOrgsList[i])
-				}
-			}
-
-			var oidcAllowedUsersList []string
-			if oidcAllowedUsers != "" {
-				oidcAllowedUsersList = strings.Split(oidcAllowedUsers, ",")
-				for i := range oidcAllowedUsersList {
-					oidcAllowedUsersList[i] = strings.TrimSpace(oidcAllowedUsersList[i])
-				}
-			}
+			googleAllowedUsersList := splitCSV(googleAllowedUsers)
+			googleAllowedWorkspacesList := splitCSV(googleAllowedWorkspaces)
+			githubAllowedUsersList := splitCSV(githubAllowedUsers)
+			githubAllowedOrgsList := splitCSV(githubAllowedOrgs)
+			oidcAllowedUsersList := splitCSV(oidcAllowedUsers)
 
 			var oidcAllowedUsersGlobList []string
 			if oidcAllowedUsersGlob != "" {
@@ -262,32 +236,13 @@ func newRootCommand(run proxyRunnerFunc) *cobra.Command {
 			oidcAllowedAttributesMap := parseAttributeMap(oidcAllowedAttributes)
 			oidcAllowedAttributesGlobMap := parseAttributeMap(oidcAllowedAttributesGlob)
 
-			var oidcScopesList []string
-			if oidcScopes != "" {
-				oidcScopesList = strings.Split(oidcScopes, ",")
-				for i := range oidcScopesList {
-					oidcScopesList[i] = strings.TrimSpace(oidcScopesList[i])
-				}
-			} else {
+			oidcScopesList := splitCSV(oidcScopes)
+			if len(oidcScopesList) == 0 {
 				oidcScopesList = []string{"openid", "profile", "email"}
 			}
 
-			var trustedProxiesList []string
-			if trustedProxies != "" {
-				trustedProxiesList = strings.Split(trustedProxies, ",")
-				for i := range trustedProxiesList {
-					trustedProxiesList[i] = strings.TrimSpace(trustedProxiesList[i])
-				}
-			}
-
-			// Parse proxy headers into slice
-			var proxyHeadersList []string
-			if proxyHeaders != "" {
-				headersList := strings.Split(proxyHeaders, ",")
-				for _, header := range headersList {
-					proxyHeadersList = append(proxyHeadersList, strings.TrimSpace(header))
-				}
-			}
+			trustedProxiesList := splitCSV(trustedProxies)
+			proxyHeadersList := splitCSV(proxyHeaders)
 
 			headerMappingMap := parseHeaderMapping(headerMapping)
 

--- a/main_test.go
+++ b/main_test.go
@@ -359,6 +359,39 @@ func TestGetEnvBoolWithDefault(t *testing.T) {
 	}
 }
 
+func TestSplitCSV(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: nil,
+		},
+		{
+			name:     "trims values",
+			input:    " user1@example.com, user2@example.com ",
+			expected: []string{"user1@example.com", "user2@example.com"},
+		},
+		{
+			name:     "keeps empty values",
+			input:    "a,,b",
+			expected: []string{"a", "", "b"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := splitCSV(tc.input)
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("Expected %v, got %v", tc.expected, result)
+			}
+		})
+	}
+}
+
 func TestNewRootCommand_HTTPStreamingOnlyFlag(t *testing.T) {
 	t.Setenv("HTTP_STREAMING_ONLY", "")
 

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -35,6 +36,9 @@ func NewOIDCProvider(
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("OIDC configuration request failed: %s", resp.Status)
+	}
 	var cfg struct {
 		AuthEndpoint  string `json:"authorization_endpoint"`
 		TokenEndpoint string `json:"token_endpoint"`
@@ -135,6 +139,9 @@ func (p *oidcProvider) Authorization(ctx context.Context, token *oauth2.Token) (
 		return false, "", nil, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return false, "", nil, fmt.Errorf("userinfo request failed: %s", resp.Status)
+	}
 	var obj any
 	if err := json.NewDecoder(resp.Body).Decode(&obj); err != nil {
 		return false, "", nil, err

--- a/pkg/auth/oidc_test.go
+++ b/pkg/auth/oidc_test.go
@@ -216,6 +216,31 @@ func TestOIDCProviderErrors(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("configuration endpoint error", func(t *testing.T) {
+		configServer := gin.New()
+		configServer.GET("/.well-known/openid_configuration", func(c *gin.Context) {
+			c.JSON(http.StatusBadGateway, gin.H{"error": "server error"})
+		})
+		tsConfig := httptest.NewServer(configServer)
+		defer tsConfig.Close()
+
+		_, err := NewOIDCProvider(
+			tsConfig.URL+"/.well-known/openid_configuration",
+			[]string{"openid"},
+			"/sub",
+			"TestOIDC",
+			TestOIDCExternalURL,
+			TestOIDCClientID,
+			TestOIDCClientSecret,
+			[]string{},
+			[]string{},
+			nil,
+			nil,
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "502 Bad Gateway")
+	})
+
 	t.Run("missing user ID field", func(t *testing.T) {
 		p, _, userinfo, tsConfig := setupOIDCTest([]string{}, "/missing_field")
 		defer tsConfig.Close()
@@ -252,6 +277,7 @@ func TestOIDCProviderErrors(t *testing.T) {
 
 		ok, _, _, err := p.Authorization(context.Background(), &oauth2.Token{AccessToken: "test-access-token"})
 		require.Error(t, err)
+		require.Contains(t, err.Error(), "500 Internal Server Error")
 		require.False(t, ok)
 	})
 }


### PR DESCRIPTION
## Summary

- Simplify repeated comma-separated CLI parsing with a shared helper.
- Return clearer errors for non-success OIDC discovery and userinfo responses.
- Add tests for CSV parsing and OIDC HTTP error handling.

## Type of Change

- [ ] **feat**: A new feature
- [x] **fix**: A bug fix
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [x] **refactor**: A code change that neither fixes a bug nor adds a feature
- [ ] **perf**: A code change that improves performance
- [x] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to our CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit

## Related Issues