### PR TITLE
feat(auth): add periodic upstream OIDC revalidation with refresh-token support

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -131,7 +131,28 @@ For Okta, you typically need to:
 
 1. Add the `groups` scope: `--oidc-scopes "openid,profile,email,groups"`
 2. Configure a groups claim in Okta Admin (Security → API → Authorization Servers → Claims)
+3. To enable upstream session revalidation with refresh-token rotation (see [Session Revalidation](#session-revalidation) below), also include the `offline_access` scope: `--oidc-scopes "openid,profile,email,groups,offline_access"`
    :::
+
+#### Session Revalidation
+
+To honor IdP-side deprovisioning (e.g. an Okta user is suspended or removed from a required group), the proxy can periodically re-contact the upstream OIDC `userinfo` endpoint and revoke all downstream tokens for the subject when the IdP rejects the upstream token.
+
+| Option                       | Environment Variable       | Default | Description                                                                                                                              |
+| ---------------------------- | -------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `--auth-revalidate-interval` | `AUTH_REVALIDATE_INTERVAL` | `60s`   | How frequently to re-validate each upstream session against the IdP (`/userinfo`). Set to `0` to disable. Currently OIDC providers only. |
+
+Behavior mirrors `oauth2-proxy`:
+
+- **Fatal errors** (`invalid_grant`, `invalid_client`, HTTP 401/403 from `/userinfo`) revoke every downstream access-token issued for the subject and force re-authentication.
+- **Non-fatal errors** (5xx, network failures) allow the request through and retry on the next interval.
+
+**Refresh tokens and `offline_access`:** Many IdPs (including Okta) only issue a refresh token when the `offline_access` scope is requested. Without a refresh token the proxy cannot rotate the upstream access token. The downstream consequence depends on how the IdP signals expiry:
+
+- If the IdP returns HTTP 401 from `/userinfo` once the upstream access token expires, the proxy treats it as fatal and forces the user to re-authenticate.
+- If the IdP returns a transient error (network failure, 5xx), the proxy allows the session to continue and retries on the next interval.
+
+Requesting `offline_access` lets the proxy refresh the upstream token transparently and avoid premature forced re-authentication. Add it to your scopes, e.g. `--oidc-scopes "openid,profile,email,offline_access"`.
 
 ### Cryptographic Key Options
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -138,14 +138,16 @@ For Okta, you typically need to:
 
 To honor IdP-side deprovisioning (e.g. an Okta user is suspended or removed from a required group), the proxy can periodically re-contact the upstream OIDC `userinfo` endpoint and revoke all downstream tokens for the subject when the IdP rejects the upstream token.
 
-| Option                       | Environment Variable       | Default | Description                                                                                                                              |
-| ---------------------------- | -------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `--auth-revalidate-interval` | `AUTH_REVALIDATE_INTERVAL` | `60s`   | How frequently to re-validate each upstream session against the IdP (`/userinfo`). Set to `0` to disable. Currently OIDC providers only. |
+| Option                         | Environment Variable         | Default | Description                                                                                                                              |
+| ------------------------------ | ---------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `--auth-revalidate-interval`   | `AUTH_REVALIDATE_INTERVAL`   | `60s`   | How frequently to re-validate each upstream session against the IdP (`/userinfo`). Set to `0` to disable. Currently OIDC providers only. |
+| `--auth-revalidate-timeout`    | `AUTH_REVALIDATE_TIMEOUT`    | `10s`   | Maximum time to wait for a single upstream re-validation call (token refresh + `/userinfo`). Exceeding it is treated as a transient failure (request allowed, warning logged). Bounds the impact of an unresponsive IdP on proxy request latency. |
+| `--auth-revalidate-on-failure` | `AUTH_REVALIDATE_ON_FAILURE` | `allow` | Behavior on non-fatal revalidation errors (timeouts, network failures, OAuth2 errors other than `invalid_grant`/`invalid_client`). `allow` (default, oauth2-proxy parity) logs a warning and proceeds; favors availability during IdP outages. `deny` revokes the subject's tokens and rejects the request; favors security and is recommended when the IdP returns non-fatal-coded errors for revoked sessions (e.g. dex returning `invalid_request` for revoked refresh tokens). |
 
-Behavior mirrors `oauth2-proxy`:
+Behavior mirrors `oauth2-proxy` by default:
 
 - **Fatal errors** (`invalid_grant`, `invalid_client`, HTTP 401/403 from `/userinfo`) revoke every downstream access-token issued for the subject and force re-authentication.
-- **Non-fatal errors** (5xx, network failures) allow the request through and retry on the next interval.
+- **Non-fatal errors** (5xx, network failures, timeouts, OAuth2 `invalid_request`, etc.) allow the request through and retry on the next interval. Set `--auth-revalidate-on-failure=deny` to revoke instead — useful when the upstream IdP returns non-fatal-coded errors for revoked sessions.
 
 **Refresh tokens and `offline_access`:** Many IdPs (including Okta) only issue a refresh token when the `offline_access` scope is requested. Without a refresh token the proxy cannot rotate the upstream access token. The downstream consequence depends on how the IdP signals expiry:
 

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"strings"
+	"time"
 
 	mcpproxy "github.com/sigbit/mcp-auth-proxy/v2/pkg/mcp-proxy"
 	"github.com/spf13/cobra"
@@ -20,6 +21,18 @@ func getEnvBoolWithDefault(key string, defaultValue bool) bool {
 		return strings.EqualFold(value, "true") || value == "1"
 	}
 	return defaultValue
+}
+
+func getEnvDurationWithDefault(key string, defaultValue time.Duration) time.Duration {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	d, err := time.ParseDuration(value)
+	if err != nil {
+		return defaultValue
+	}
+	return d
 }
 
 func splitCSV(s string) []string {
@@ -86,12 +99,12 @@ func parseAttributeMap(s string) map[string][]string {
 		if part == "" {
 			continue
 		}
-		eqIdx := strings.Index(part, "=")
-		if eqIdx == -1 {
+		before, after, ok := strings.Cut(part, "=")
+		if !ok {
 			continue
 		}
-		key := strings.TrimSpace(part[:eqIdx])
-		value := strings.TrimSpace(part[eqIdx+1:])
+		key := strings.TrimSpace(before)
+		value := strings.TrimSpace(after)
 		if key != "" && value != "" {
 			result[key] = append(result[key], value)
 		}
@@ -167,6 +180,7 @@ type proxyRunnerFunc func(
 	httpStreamingOnly bool,
 	headerMapping map[string]string,
 	headerMappingBase string,
+	authRevalidateInterval time.Duration,
 ) error
 
 func main() {
@@ -218,6 +232,7 @@ func newRootCommand(run proxyRunnerFunc) *cobra.Command {
 	var headerMappingBase string
 	var httpStreamingOnly bool
 	var trustedProxies string
+	var authRevalidateInterval time.Duration
 
 	rootCmd := &cobra.Command{
 		Use: "mcp-warp",
@@ -290,6 +305,7 @@ func newRootCommand(run proxyRunnerFunc) *cobra.Command {
 				httpStreamingOnly,
 				headerMappingMap,
 				headerMappingBase,
+				authRevalidateInterval,
 			); err != nil {
 				panic(err)
 			}
@@ -348,6 +364,7 @@ func newRootCommand(run proxyRunnerFunc) *cobra.Command {
 	rootCmd.Flags().BoolVar(&httpStreamingOnly, "http-streaming-only", getEnvBoolWithDefault("HTTP_STREAMING_ONLY", false), "Reject SSE (GET) requests and keep the backend in HTTP streaming-only mode")
 	rootCmd.Flags().StringVar(&headerMapping, "header-mapping", getEnvWithDefault("HEADER_MAPPING", ""), "Comma-separated mapping of JSON pointer paths to header names (e.g., /email:X-Forwarded-Email,/preferred_username:X-Forwarded-User)")
 	rootCmd.Flags().StringVar(&headerMappingBase, "header-mapping-base", getEnvWithDefault("HEADER_MAPPING_BASE", "/userinfo"), "JSON pointer base path for header mapping claims lookup (e.g., /userinfo or /)")
+	rootCmd.Flags().DurationVar(&authRevalidateInterval, "auth-revalidate-interval", getEnvDurationWithDefault("AUTH_REVALIDATE_INTERVAL", 60*time.Second), "Periodic upstream OIDC re-validation interval (e.g. 60s, 5m). Set to 0 to disable. For graceful refresh-token rotation, request the 'offline_access' scope (e.g. add it to --oidc-scopes); otherwise the upstream access token cannot be refreshed and the user will be forced to re-authenticate when it expires.")
 
 	return rootCmd
 }

--- a/main.go
+++ b/main.go
@@ -253,7 +253,7 @@ func newRootCommand(run proxyRunnerFunc) *cobra.Command {
 
 			oidcScopesList := splitCSV(oidcScopes)
 			if len(oidcScopesList) == 0 {
-				oidcScopesList = []string{"openid", "profile", "email"}
+				oidcScopesList = []string{"openid", "profile", "email", "offline_access"}
 			}
 
 			trustedProxiesList := splitCSV(trustedProxies)
@@ -343,7 +343,7 @@ func newRootCommand(run proxyRunnerFunc) *cobra.Command {
 	rootCmd.Flags().StringVar(&oidcConfigurationURL, "oidc-configuration-url", getEnvWithDefault("OIDC_CONFIGURATION_URL", ""), "OIDC configuration URL")
 	rootCmd.Flags().StringVar(&oidcClientID, "oidc-client-id", getEnvWithDefault("OIDC_CLIENT_ID", ""), "OIDC client ID")
 	rootCmd.Flags().StringVar(&oidcClientSecret, "oidc-client-secret", getEnvWithDefault("OIDC_CLIENT_SECRET", ""), "OIDC client secret")
-	rootCmd.Flags().StringVar(&oidcScopes, "oidc-scopes", getEnvWithDefault("OIDC_SCOPES", "openid,profile,email"), "Comma-separated list of OIDC scopes")
+	rootCmd.Flags().StringVar(&oidcScopes, "oidc-scopes", getEnvWithDefault("OIDC_SCOPES", "openid,profile,email,offline_access"), "Comma-separated list of OIDC scopes")
 	rootCmd.Flags().StringVar(&oidcUserIDField, "oidc-user-id-field", getEnvWithDefault("OIDC_USER_ID_FIELD", "/email"), "JSON pointer to user ID field in userinfo endpoint response")
 	rootCmd.Flags().StringVar(&oidcProviderName, "oidc-provider-name", getEnvWithDefault("OIDC_PROVIDER_NAME", "OIDC"), "Display name for OIDC provider")
 	rootCmd.Flags().StringVar(&oidcAllowedUsers, "oidc-allowed-users", getEnvWithDefault("OIDC_ALLOWED_USERS", ""), "Comma-separated list of allowed OIDC users")

--- a/main.go
+++ b/main.go
@@ -181,6 +181,8 @@ type proxyRunnerFunc func(
 	headerMapping map[string]string,
 	headerMappingBase string,
 	authRevalidateInterval time.Duration,
+	authRevalidateTimeout time.Duration,
+	authRevalidateOnFailure string,
 ) error
 
 func main() {
@@ -233,6 +235,8 @@ func newRootCommand(run proxyRunnerFunc) *cobra.Command {
 	var httpStreamingOnly bool
 	var trustedProxies string
 	var authRevalidateInterval time.Duration
+	var authRevalidateTimeout time.Duration
+	var authRevalidateOnFailure string
 
 	rootCmd := &cobra.Command{
 		Use: "mcp-warp",
@@ -306,6 +310,8 @@ func newRootCommand(run proxyRunnerFunc) *cobra.Command {
 				headerMappingMap,
 				headerMappingBase,
 				authRevalidateInterval,
+				authRevalidateTimeout,
+				authRevalidateOnFailure,
 			); err != nil {
 				panic(err)
 			}
@@ -365,6 +371,8 @@ func newRootCommand(run proxyRunnerFunc) *cobra.Command {
 	rootCmd.Flags().StringVar(&headerMapping, "header-mapping", getEnvWithDefault("HEADER_MAPPING", ""), "Comma-separated mapping of JSON pointer paths to header names (e.g., /email:X-Forwarded-Email,/preferred_username:X-Forwarded-User)")
 	rootCmd.Flags().StringVar(&headerMappingBase, "header-mapping-base", getEnvWithDefault("HEADER_MAPPING_BASE", "/userinfo"), "JSON pointer base path for header mapping claims lookup (e.g., /userinfo or /)")
 	rootCmd.Flags().DurationVar(&authRevalidateInterval, "auth-revalidate-interval", getEnvDurationWithDefault("AUTH_REVALIDATE_INTERVAL", 60*time.Second), "Periodic upstream OIDC re-validation interval (e.g. 60s, 5m). Set to 0 to disable. For graceful refresh-token rotation, request the 'offline_access' scope (e.g. add it to --oidc-scopes); otherwise the upstream access token cannot be refreshed and the user will be forced to re-authenticate when it expires.")
+	rootCmd.Flags().DurationVar(&authRevalidateTimeout, "auth-revalidate-timeout", getEnvDurationWithDefault("AUTH_REVALIDATE_TIMEOUT", 10*time.Second), "Maximum time to wait for a single upstream OIDC re-validation call (token refresh + userinfo). If exceeded, the call is treated as a transient failure (request allowed, warning logged). Bounds the impact of an unresponsive IdP on proxy request latency. Set <=0 to use the default (10s).")
+	rootCmd.Flags().StringVar(&authRevalidateOnFailure, "auth-revalidate-on-failure", getEnvWithDefault("AUTH_REVALIDATE_ON_FAILURE", "allow"), "Behavior when revalidation returns a non-fatal error (timeout, network failure, OAuth2 errors other than invalid_grant/invalid_client). 'allow' (default, oauth2-proxy parity): log a warning and proceed; favors availability during IdP outages. 'deny': revoke the subject's tokens and reject the request; favors security and is recommended when the IdP returns non-fatal-coded errors for revoked sessions (e.g. dex returning invalid_request for revoked refresh tokens).")
 
 	return rootCmd
 }

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestSplitWithEscapes(t *testing.T) {
@@ -440,6 +441,7 @@ func TestNewRootCommand_HTTPStreamingOnlyFlag(t *testing.T) {
 		httpStreamingOnly bool,
 		headerMapping map[string]string,
 		headerMappingBase string,
+		authRevalidateInterval time.Duration,
 	) error {
 		streamingOnly = httpStreamingOnly
 		receivedTargets = proxyTarget
@@ -508,6 +510,7 @@ func TestNewRootCommand_HTTPStreamingOnlyFromEnv(t *testing.T) {
 		httpStreamingOnly bool,
 		headerMapping map[string]string,
 		headerMappingBase string,
+		authRevalidateInterval time.Duration,
 	) error {
 		streamingOnly = httpStreamingOnly
 		return nil
@@ -572,6 +575,7 @@ func TestNewRootCommand_ForwardAuthorizationFlag(t *testing.T) {
 		httpStreamingOnly bool,
 		headerMapping map[string]string,
 		headerMappingBase string,
+		authRevalidateInterval time.Duration,
 	) error {
 		forwardAuthorization = forwardAuthorizationHeader
 		return nil
@@ -636,6 +640,7 @@ func TestNewRootCommand_ForwardAuthorizationFromEnv(t *testing.T) {
 		httpStreamingOnly bool,
 		headerMapping map[string]string,
 		headerMappingBase string,
+		authRevalidateInterval time.Duration,
 	) error {
 		forwardAuthorization = forwardAuthorizationHeader
 		return nil

--- a/main_test.go
+++ b/main_test.go
@@ -442,6 +442,8 @@ func TestNewRootCommand_HTTPStreamingOnlyFlag(t *testing.T) {
 		headerMapping map[string]string,
 		headerMappingBase string,
 		authRevalidateInterval time.Duration,
+		authRevalidateTimeout time.Duration,
+		authRevalidateOnFailure string,
 	) error {
 		streamingOnly = httpStreamingOnly
 		receivedTargets = proxyTarget
@@ -511,6 +513,8 @@ func TestNewRootCommand_HTTPStreamingOnlyFromEnv(t *testing.T) {
 		headerMapping map[string]string,
 		headerMappingBase string,
 		authRevalidateInterval time.Duration,
+		authRevalidateTimeout time.Duration,
+		authRevalidateOnFailure string,
 	) error {
 		streamingOnly = httpStreamingOnly
 		return nil
@@ -576,6 +580,8 @@ func TestNewRootCommand_ForwardAuthorizationFlag(t *testing.T) {
 		headerMapping map[string]string,
 		headerMappingBase string,
 		authRevalidateInterval time.Duration,
+		authRevalidateTimeout time.Duration,
+		authRevalidateOnFailure string,
 	) error {
 		forwardAuthorization = forwardAuthorizationHeader
 		return nil
@@ -641,6 +647,8 @@ func TestNewRootCommand_ForwardAuthorizationFromEnv(t *testing.T) {
 		headerMapping map[string]string,
 		headerMappingBase string,
 		authRevalidateInterval time.Duration,
+		authRevalidateTimeout time.Duration,
+		authRevalidateOnFailure string,
 	) error {
 		forwardAuthorization = forwardAuthorizationHeader
 		return nil

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -72,11 +72,13 @@ const (
 	PasswordProvider = "password"
 	PasswordUserID   = "password_user"
 
-	SessionKeyAuthorized  = "authorized"
-	SessionKeyRedirectURL = "redirect_url"
-	SessionKeyOAuthState  = "oauth_state"
-	SessionKeyUserID      = "user_id"
-	SessionKeyUserInfo    = "user_info"
+	SessionKeyAuthorized   = "authorized"
+	SessionKeyRedirectURL  = "redirect_url"
+	SessionKeyOAuthState   = "oauth_state"
+	SessionKeyUserID       = "user_id"
+	SessionKeyUserInfo     = "user_info"
+	SessionKeyProviderName = "provider_name"
+	SessionKeyUpstreamTok  = "upstream_token"
 )
 
 func (a *AuthRouter) SetupRoutes(router gin.IRouter) {
@@ -107,6 +109,10 @@ func (a *AuthRouter) SetupRoutes(router gin.IRouter) {
 			}
 			session.Set(SessionKeyAuthorized, true)
 			session.Set(SessionKeyUserID, user)
+			session.Set(SessionKeyProviderName, provider.Name())
+			if tokenJSON, err := json.Marshal(token); err == nil {
+				session.Set(SessionKeyUpstreamTok, string(tokenJSON))
+			}
 			if userInfo != nil {
 				if len(a.userInfoFields) > 0 {
 					userInfo = filterUserInfo(userInfo, a.userInfoFields)

--- a/pkg/auth/interface.go
+++ b/pkg/auth/interface.go
@@ -17,3 +17,34 @@ type Provider interface {
 	Exchange(c *gin.Context, state string) (*oauth2.Token, error)
 	Authorization(ctx context.Context, token *oauth2.Token) (bool, string, map[string]any, error)
 }
+
+// Revalidator is an optional interface that providers may implement to support
+// periodic upstream re-validation of an existing session. Implementations should
+// re-contact the IdP (e.g. an OIDC userinfo endpoint), refresh the upstream
+// access token if necessary, and report whether the user is still authorized.
+//
+// The returned token, if non-nil, supersedes the input token and should be
+// persisted by the caller. If err is a FatalRevalidationError, callers MUST
+// treat the session as terminated (revoke the downstream token and force the
+// user to re-authenticate). All other errors are non-fatal and the existing
+// session should be allowed to continue (with a retry on the next interval).
+type Revalidator interface {
+	Revalidate(ctx context.Context, token *oauth2.Token) (allowed bool, newToken *oauth2.Token, err error)
+}
+
+// FatalRevalidationError indicates that revalidation failed in a way that the
+// upstream IdP considers terminal (e.g. invalid_grant, invalid_client, 401/403
+// from userinfo). Sessions returning this error must be invalidated.
+type FatalRevalidationError struct {
+	Reason string
+	Err    error
+}
+
+func (e *FatalRevalidationError) Error() string {
+	if e.Err == nil {
+		return "fatal revalidation error: " + e.Reason
+	}
+	return "fatal revalidation error: " + e.Reason + ": " + e.Err.Error()
+}
+
+func (e *FatalRevalidationError) Unwrap() error { return e.Err }

--- a/pkg/auth/mock.go
+++ b/pkg/auth/mock.go
@@ -144,3 +144,43 @@ func (mr *MockProviderMockRecorder) Type() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockProvider)(nil).Type))
 }
+
+// MockRevalidator is a mock of Revalidator interface.
+type MockRevalidator struct {
+	ctrl     *gomock.Controller
+	recorder *MockRevalidatorMockRecorder
+	isgomock struct{}
+}
+
+// MockRevalidatorMockRecorder is the mock recorder for MockRevalidator.
+type MockRevalidatorMockRecorder struct {
+	mock *MockRevalidator
+}
+
+// NewMockRevalidator creates a new mock instance.
+func NewMockRevalidator(ctrl *gomock.Controller) *MockRevalidator {
+	mock := &MockRevalidator{ctrl: ctrl}
+	mock.recorder = &MockRevalidatorMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRevalidator) EXPECT() *MockRevalidatorMockRecorder {
+	return m.recorder
+}
+
+// Revalidate mocks base method.
+func (m *MockRevalidator) Revalidate(ctx context.Context, token *oauth2.Token) (bool, *oauth2.Token, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Revalidate", ctx, token)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(*oauth2.Token)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// Revalidate indicates an expected call of Revalidate.
+func (mr *MockRevalidatorMockRecorder) Revalidate(ctx, token any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revalidate", reflect.TypeOf((*MockRevalidator)(nil).Revalidate), ctx, token)
+}

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gobwas/glob"
@@ -217,6 +218,131 @@ func matchAttributeValue(attrValue any, allowedValues []string) bool {
 		}
 	}
 	return false
+}
+
+// Revalidate implements Revalidator by re-querying the OIDC userinfo endpoint
+// using the supplied upstream token. If the access token is expired (or near
+// expiry per oauth2 internal skew), the underlying TokenSource will transparently
+// use the refresh token to obtain a new one. The (potentially refreshed) token
+// is returned so the caller can persist it.
+//
+// Fatal classification mirrors oauth2-proxy semantics:
+//   - HTTP 401/403 from userinfo  -> fatal
+//   - oauth2 *RetrieveError whose body contains "invalid_grant" or
+//     "invalid_client" (RFC 6749 §5.2) -> fatal
+//   - Network / 5xx / decode errors -> non-fatal
+func (p *oidcProvider) Revalidate(ctx context.Context, token *oauth2.Token) (bool, *oauth2.Token, error) {
+	if token == nil {
+		return false, nil, &FatalRevalidationError{Reason: "missing upstream token"}
+	}
+
+	ts := p.oauth2.TokenSource(ctx, token)
+	refreshed, err := ts.Token()
+	if err != nil {
+		if isFatalOAuth2Error(err) {
+			return false, nil, &FatalRevalidationError{Reason: "token refresh rejected", Err: err}
+		}
+		return false, nil, fmt.Errorf("token refresh failed: %w", err)
+	}
+
+	client := oauth2.NewClient(ctx, oauth2.StaticTokenSource(refreshed))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.userInfoURL, nil)
+	if err != nil {
+		return false, nil, fmt.Errorf("build userinfo request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, nil, fmt.Errorf("userinfo request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		return false, nil, &FatalRevalidationError{Reason: fmt.Sprintf("userinfo returned %s", resp.Status)}
+	case resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices:
+		return false, nil, fmt.Errorf("userinfo request failed: %s", resp.Status)
+	}
+
+	var obj any
+	if err := json.NewDecoder(resp.Body).Decode(&obj); err != nil {
+		return false, nil, fmt.Errorf("decode userinfo response: %w", err)
+	}
+	userInfoMap, ok := obj.(map[string]any)
+	if !ok {
+		return false, nil, errors.New("userinfo response is not a JSON object")
+	}
+	v, err := jsonpointer.Get(obj, p.userIDField)
+	if err != nil {
+		return false, nil, err
+	}
+	userID, ok := v.(string)
+	if !ok {
+		return false, nil, errors.New("user ID field is not a string")
+	}
+
+	allowed := p.matchAuthorization(userID, userInfoMap)
+	return allowed, refreshed, nil
+}
+
+// matchAuthorization mirrors the allow-list logic in Authorization, factored
+// out so Revalidate can reuse it without re-issuing a userinfo request.
+func (p *oidcProvider) matchAuthorization(userID string, userInfo map[string]any) bool {
+	if len(p.allowedUsers) == 0 && len(p.allowedUsersGlob) == 0 && len(p.allowedAttributes) == 0 && len(p.allowedAttributesGlob) == 0 {
+		return true
+	}
+	if slices.Contains(p.allowedUsers, userID) {
+		return true
+	}
+	for _, g := range p.allowedUsersGlob {
+		if g.Match(userID) {
+			return true
+		}
+	}
+	for key, allowedValues := range p.allowedAttributes {
+		attrValue, err := jsonpointer.Get(userInfo, key)
+		if err != nil {
+			continue
+		}
+		if matchAttributeValue(attrValue, allowedValues) {
+			return true
+		}
+	}
+	for key, globs := range p.allowedAttributesGlob {
+		attrValue, err := jsonpointer.Get(userInfo, key)
+		if err != nil {
+			continue
+		}
+		if matchAttributeGlob(attrValue, globs) {
+			return true
+		}
+	}
+	return false
+}
+
+// isFatalOAuth2Error returns true for errors that the IdP considers terminal
+// per RFC 6749 §5.2 (invalid_grant, invalid_client). Detection mirrors
+// oauth2-proxy: substring match on the error body since the upstream
+// golang.org/x/oauth2 *RetrieveError stringification varies by version.
+func isFatalOAuth2Error(err error) bool {
+	if err == nil {
+		return false
+	}
+	var re *oauth2.RetrieveError
+	if errors.As(err, &re) {
+		if re.Response != nil && (re.Response.StatusCode == http.StatusUnauthorized || re.Response.StatusCode == http.StatusForbidden) {
+			return true
+		}
+		if re.ErrorCode == "invalid_grant" || re.ErrorCode == "invalid_client" {
+			return true
+		}
+		body := strings.ToLower(string(re.Body))
+		if strings.Contains(body, "invalid_grant") || strings.Contains(body, "invalid_client") {
+			return true
+		}
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "invalid_grant") || strings.Contains(msg, "invalid_client")
 }
 
 // matchAttributeGlob checks if an attribute value matches any of the glob patterns.

--- a/pkg/auth/oidc_test.go
+++ b/pkg/auth/oidc_test.go
@@ -286,7 +286,7 @@ func TestOIDCProviderGlobPatterns(t *testing.T) {
 	// Setup test server with OIDC configuration
 	configServer := gin.New()
 	configServer.GET("/.well-known/openid_configuration", func(c *gin.Context) {
-		c.JSON(200, map[string]interface{}{
+		c.JSON(200, map[string]any{
 			"authorization_endpoint": "http://localhost/auth",
 			"token_endpoint":         "http://localhost/token",
 			"userinfo_endpoint":      "http://localhost/userinfo",
@@ -330,7 +330,7 @@ func TestOIDCProviderGlobPatterns(t *testing.T) {
 			// Mock userinfo endpoint
 			userServer := gin.New()
 			userServer.GET("/userinfo", func(c *gin.Context) {
-				c.JSON(200, map[string]interface{}{
+				c.JSON(200, map[string]any{
 					"email": tc.email,
 				})
 			})
@@ -354,7 +354,7 @@ func TestOIDCProviderAttributeMatching(t *testing.T) {
 	// Setup test server with OIDC configuration
 	configServer := gin.New()
 	configServer.GET("/.well-known/openid_configuration", func(c *gin.Context) {
-		c.JSON(200, map[string]interface{}{
+		c.JSON(200, map[string]any{
 			"authorization_endpoint": "http://localhost/auth",
 			"token_endpoint":         "http://localhost/token",
 			"userinfo_endpoint":      "http://localhost/userinfo",
@@ -367,79 +367,79 @@ func TestOIDCProviderAttributeMatching(t *testing.T) {
 		name                  string
 		allowedAttributes     map[string][]string
 		allowedAttributesGlob map[string][]string
-		userInfo              map[string]interface{}
+		userInfo              map[string]any
 		expected              bool
 	}{
 		{
 			name:              "allow all when no restrictions",
 			allowedAttributes: nil,
-			userInfo:          map[string]interface{}{"sub": "user1", "email": "user@example.com"},
+			userInfo:          map[string]any{"sub": "user1", "email": "user@example.com"},
 			expected:          true,
 		},
 		{
 			name:              "exact match on string attribute",
 			allowedAttributes: map[string][]string{"/department": {"engineering"}},
-			userInfo:          map[string]interface{}{"sub": "user1", "email": "user@example.com", "department": "engineering"},
+			userInfo:          map[string]any{"sub": "user1", "email": "user@example.com", "department": "engineering"},
 			expected:          true,
 		},
 		{
 			name:              "no match on string attribute",
 			allowedAttributes: map[string][]string{"/department": {"engineering"}},
-			userInfo:          map[string]interface{}{"sub": "user1", "email": "user@example.com", "department": "marketing"},
+			userInfo:          map[string]any{"sub": "user1", "email": "user@example.com", "department": "marketing"},
 			expected:          false,
 		},
 		{
 			name:              "match on array attribute",
 			allowedAttributes: map[string][]string{"/groups": {"admin"}},
-			userInfo:          map[string]interface{}{"sub": "user1", "email": "user@example.com", "groups": []interface{}{"users", "admin"}},
+			userInfo:          map[string]any{"sub": "user1", "email": "user@example.com", "groups": []any{"users", "admin"}},
 			expected:          true,
 		},
 		{
 			name:              "no match on array attribute",
 			allowedAttributes: map[string][]string{"/groups": {"admin"}},
-			userInfo:          map[string]interface{}{"sub": "user1", "email": "user@example.com", "groups": []interface{}{"users", "developers"}},
+			userInfo:          map[string]any{"sub": "user1", "email": "user@example.com", "groups": []any{"users", "developers"}},
 			expected:          false,
 		},
 		{
 			name:              "multiple allowed values - match",
 			allowedAttributes: map[string][]string{"/role": {"admin", "moderator"}},
-			userInfo:          map[string]interface{}{"sub": "user1", "email": "user@example.com", "role": "moderator"},
+			userInfo:          map[string]any{"sub": "user1", "email": "user@example.com", "role": "moderator"},
 			expected:          true,
 		},
 		{
 			name:              "nested attribute match",
 			allowedAttributes: map[string][]string{"/org/team": {"platform"}},
-			userInfo:          map[string]interface{}{"sub": "user1", "email": "user@example.com", "org": map[string]interface{}{"team": "platform"}},
+			userInfo:          map[string]any{"sub": "user1", "email": "user@example.com", "org": map[string]any{"team": "platform"}},
 			expected:          true,
 		},
 		{
 			name:                  "glob pattern match on string",
 			allowedAttributesGlob: map[string][]string{"/department": {"eng*"}},
-			userInfo:              map[string]interface{}{"sub": "user1", "email": "user@example.com", "department": "engineering"},
+			userInfo:              map[string]any{"sub": "user1", "email": "user@example.com", "department": "engineering"},
 			expected:              true,
 		},
 		{
 			name:                  "glob pattern no match on string",
 			allowedAttributesGlob: map[string][]string{"/department": {"eng*"}},
-			userInfo:              map[string]interface{}{"sub": "user1", "email": "user@example.com", "department": "marketing"},
+			userInfo:              map[string]any{"sub": "user1", "email": "user@example.com", "department": "marketing"},
 			expected:              false,
 		},
 		{
 			name:                  "glob pattern match on array",
 			allowedAttributesGlob: map[string][]string{"/groups": {"*-admins"}},
-			userInfo:              map[string]interface{}{"sub": "user1", "email": "user@example.com", "groups": []interface{}{"users", "platform-admins"}},
+			userInfo:              map[string]any{"sub": "user1", "email": "user@example.com", "groups": []any{"users", "platform-admins"}},
 			expected:              true,
 		},
 		{
 			name:                  "glob pattern no match on array",
 			allowedAttributesGlob: map[string][]string{"/groups": {"*-admins"}},
-			userInfo:              map[string]interface{}{"sub": "user1", "email": "user@example.com", "groups": []interface{}{"users", "developers"}},
+			userInfo:              map[string]any{"sub": "user1", "email": "user@example.com", "groups": []any{"users", "developers"}},
 			expected:              false,
 		},
 		{
 			name:              "missing attribute - no match",
 			allowedAttributes: map[string][]string{"/department": {"engineering"}},
-			userInfo:          map[string]interface{}{"sub": "user1", "email": "user@example.com"},
+			userInfo:          map[string]any{"sub": "user1", "email": "user@example.com"},
 			expected:          false,
 		},
 	}

--- a/pkg/idp/idp.go
+++ b/pkg/idp/idp.go
@@ -5,9 +5,11 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
+	"maps"
 	"math/big"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -32,6 +34,16 @@ type IDPRouter struct {
 	provider    fosite.OAuth2Provider
 	signer      *jwt.DefaultSigner
 	authRouter  *auth.AuthRouter
+}
+
+// oauth2Token is a JSON-compatible projection of *golang.org/x/oauth2.Token.
+// We define it locally to avoid coupling this package to the oauth2 library
+// solely for unmarshalling a payload that was JSON-encoded upstream.
+type oauth2Token struct {
+	AccessToken  string    `json:"access_token"`
+	TokenType    string    `json:"token_type,omitempty"`
+	RefreshToken string    `json:"refresh_token,omitempty"`
+	Expiry       time.Time `json:"expiry"`
 }
 
 func NewIDPRouter(
@@ -202,6 +214,29 @@ func (a *IDPRouter) handleAuthorizationReturn(c *gin.Context) {
 		json.Unmarshal([]byte(userInfoJSON), &userInfo)
 	}
 
+	// Persist the upstream IdP token for periodic revalidation. This is best-effort:
+	// a storage failure must not block the user from authenticating, but it does
+	// disable revalidation for this session until the next login.
+	if tokenJSON, ok := session.Get(auth.SessionKeyUpstreamTok).(string); ok && tokenJSON != "" && subject != "user" {
+		var tok oauth2Token
+		if err := json.Unmarshal([]byte(tokenJSON), &tok); err == nil {
+			providerName, _ := session.Get(auth.SessionKeyProviderName).(string)
+			upSess := &repository.UpstreamSession{
+				Subject:      subject,
+				Provider:     providerName,
+				AccessToken:  tok.AccessToken,
+				RefreshToken: tok.RefreshToken,
+				TokenType:    tok.TokenType,
+				Expiry:       tok.Expiry,
+				LastChecked:  time.Now().UTC(),
+			}
+			if err := a.repo.PutUpstreamSession(ctx, upSess); err != nil {
+				a.logger.Warn("Failed to persist upstream session for revalidation",
+					zap.String("subject", subject), zap.Error(err))
+			}
+		}
+	}
+
 	jwtSession, err := NewJWTSessionWithKey(a.externalURL, subject, a.privKey, userInfo)
 	if err != nil {
 		a.logger.With(utils.Err(err)...).Error("Failed to create JWT session", zap.Error(err))
@@ -249,12 +284,7 @@ func addAuthorizeRequestID(session sessions.Session, arID string) {
 }
 
 func hasAuthorizeRequestID(session sessions.Session, arID string) bool {
-	for _, id := range authorizeRequestIDs(session) {
-		if id == arID {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(authorizeRequestIDs(session), arID)
 }
 
 func removeAuthorizeRequestID(session sessions.Session, arID string) {
@@ -577,9 +607,7 @@ func (s *Session) Clone() fosite.Session {
 		},
 	}
 
-	for k, v := range s.JWTHeader.Extra {
-		clone.JWTHeader.Extra[k] = v
-	}
+	maps.Copy(clone.JWTHeader.Extra, s.JWTHeader.Extra)
 
 	return clone
 }

--- a/pkg/mcp-proxy/main.go
+++ b/pkg/mcp-proxy/main.go
@@ -82,6 +82,8 @@ func Run(
 	headerMapping map[string]string,
 	headerMappingBase string,
 	authRevalidateInterval time.Duration,
+	authRevalidateTimeout time.Duration,
+	authRevalidateOnFailure string,
 ) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
@@ -303,10 +305,12 @@ func Run(
 		return fmt.Errorf("failed to create IDP router: %w", err)
 	}
 	proxyRouter, err := newProxyRouter(externalURL, beHandler, &privKey.PublicKey, proxyHeadersMap, httpStreamingOnly, forwardAuthorizationHeader, headerMapping, headerMappingBase, &proxy.Options{
-		Repo:               repo,
-		Providers:          providers,
-		RevalidateInterval: authRevalidateInterval,
-		Logger:             logger,
+		Repo:                repo,
+		Providers:           providers,
+		RevalidateInterval:  authRevalidateInterval,
+		RevalidateTimeout:   authRevalidateTimeout,
+		RevalidateOnFailure: proxy.RevalidateOnFailure(authRevalidateOnFailure),
+		Logger:              logger,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create proxy router: %w", err)

--- a/pkg/mcp-proxy/main.go
+++ b/pkg/mcp-proxy/main.go
@@ -81,6 +81,7 @@ func Run(
 	httpStreamingOnly bool,
 	headerMapping map[string]string,
 	headerMappingBase string,
+	authRevalidateInterval time.Duration,
 ) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
@@ -301,7 +302,12 @@ func Run(
 	if err != nil {
 		return fmt.Errorf("failed to create IDP router: %w", err)
 	}
-	proxyRouter, err := newProxyRouter(externalURL, beHandler, &privKey.PublicKey, proxyHeadersMap, httpStreamingOnly, forwardAuthorizationHeader, headerMapping, headerMappingBase)
+	proxyRouter, err := newProxyRouter(externalURL, beHandler, &privKey.PublicKey, proxyHeadersMap, httpStreamingOnly, forwardAuthorizationHeader, headerMapping, headerMappingBase, &proxy.Options{
+		Repo:               repo,
+		Providers:          providers,
+		RevalidateInterval: authRevalidateInterval,
+		Logger:             logger,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to create proxy router: %w", err)
 	}
@@ -371,9 +377,7 @@ func Run(
 			Handler:   router,
 			TLSConfig: &tls.Config{GetCertificate: certReloader.GetCertificate},
 		}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			err := httpServer.ListenAndServe()
 			if err != nil && !errors.Is(err, http.ErrServerClosed) {
 				lock.Lock()
@@ -382,7 +386,7 @@ func Run(
 			}
 			logger.Debug("HTTP server closed")
 			exit <- struct{}{}
-		}()
+		})
 		go func() {
 			<-ctx.Done()
 			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), ServerShutdownTimeout)
@@ -391,9 +395,7 @@ func Run(
 				logger.Warn("HTTP server shutdown error", zap.Error(shutdownErr))
 			}
 		}()
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			err := httpsServer.ListenAndServeTLS("", "")
 			if err != nil && !errors.Is(err, http.ErrServerClosed) {
 				lock.Lock()
@@ -402,7 +404,7 @@ func Run(
 			}
 			logger.Debug("HTTPS server closed")
 			exit <- struct{}{}
-		}()
+		})
 		go func() {
 			<-ctx.Done()
 			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), ServerShutdownTimeout)
@@ -446,9 +448,7 @@ func Run(
 			Handler:   router,
 			TLSConfig: m.TLSConfig(),
 		}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			err := httpServer.ListenAndServe()
 			if err != nil && !errors.Is(err, http.ErrServerClosed) {
 				lock.Lock()
@@ -457,7 +457,7 @@ func Run(
 			}
 			logger.Debug("HTTP server closed")
 			exit <- struct{}{}
-		}()
+		})
 		go func() {
 			<-ctx.Done()
 			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), ServerShutdownTimeout)
@@ -467,9 +467,7 @@ func Run(
 			}
 		}()
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			err := httpsServer.ListenAndServeTLS("", "")
 			if err != nil && !errors.Is(err, http.ErrServerClosed) {
 				lock.Lock()
@@ -478,7 +476,7 @@ func Run(
 			}
 			logger.Debug("HTTPS server closed")
 			exit <- struct{}{}
-		}()
+		})
 		go func() {
 			<-ctx.Done()
 			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), ServerShutdownTimeout)
@@ -492,9 +490,7 @@ func Run(
 			Addr:    listen,
 			Handler: router,
 		}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			err := httpServer.ListenAndServe()
 			if err != nil && !errors.Is(err, http.ErrServerClosed) {
 				lock.Lock()
@@ -502,7 +498,7 @@ func Run(
 				lock.Unlock()
 			}
 			exit <- struct{}{}
-		}()
+		})
 		go func() {
 			<-ctx.Done()
 			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), ServerShutdownTimeout)
@@ -514,9 +510,7 @@ func Run(
 	}
 
 	if be != nil {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			if err := be.Wait(); err != nil && !errors.Is(ctx.Err(), context.Canceled) {
 				lock.Lock()
 				errs = append(errs, err)
@@ -524,7 +518,7 @@ func Run(
 			}
 			logger.Debug("proxy backend closed")
 			exit <- struct{}{}
-		}()
+		})
 	}
 
 	if manualTLS || tlsHost != "" {

--- a/pkg/mcp-proxy/main_test.go
+++ b/pkg/mcp-proxy/main_test.go
@@ -35,7 +35,7 @@ func TestRun_NormalizesExternalURLTrailingSlash(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			var receivedURL string
-			newProxyRouter = func(externalURL string, proxyHandler http.Handler, publicKey *rsa.PublicKey, proxyHeaders http.Header, httpStreamingOnly bool, forwardAuthorizationHeader bool, headerMapping map[string]string, headerMappingBase string) (*proxy.ProxyRouter, error) {
+			newProxyRouter = func(externalURL string, proxyHandler http.Handler, publicKey *rsa.PublicKey, proxyHeaders http.Header, httpStreamingOnly bool, forwardAuthorizationHeader bool, headerMapping map[string]string, headerMappingBase string, _ *proxy.Options) (*proxy.ProxyRouter, error) {
 				receivedURL = externalURL
 				return nil, errors.New("stop early")
 			}
@@ -48,7 +48,7 @@ func TestRun_NormalizesExternalURLTrailingSlash(t *testing.T) {
 				"", "", "", "", nil, nil,
 				"", "", "", nil, "", "", nil, nil, nil, nil,
 				false, "", "", nil, nil, "", false,
-				[]string{"http://example.com"}, false, nil, "/userinfo",
+				[]string{"http://example.com"}, false, nil, "/userinfo", 0,
 			)
 
 			if tt.wantErr {
@@ -71,7 +71,7 @@ func TestRun_PassesHTTPStreamingOnlyToProxyRouter(t *testing.T) {
 	})
 
 	var streamingOnlyReceived bool
-	newProxyRouter = func(externalURL string, proxyHandler http.Handler, publicKey *rsa.PublicKey, proxyHeaders http.Header, httpStreamingOnly bool, forwardAuthorizationHeader bool, headerMapping map[string]string, headerMappingBase string) (*proxy.ProxyRouter, error) {
+	newProxyRouter = func(externalURL string, proxyHandler http.Handler, publicKey *rsa.PublicKey, proxyHeaders http.Header, httpStreamingOnly bool, forwardAuthorizationHeader bool, headerMapping map[string]string, headerMappingBase string, _ *proxy.Options) (*proxy.ProxyRouter, error) {
 		streamingOnlyReceived = httpStreamingOnly
 		return nil, errors.New("proxy router init failed")
 	}
@@ -120,6 +120,7 @@ func TestRun_PassesHTTPStreamingOnlyToProxyRouter(t *testing.T) {
 		true,
 		nil,
 		"/userinfo",
+		0,
 	)
 
 	require.Error(t, err)

--- a/pkg/mcp-proxy/main_test.go
+++ b/pkg/mcp-proxy/main_test.go
@@ -48,7 +48,7 @@ func TestRun_NormalizesExternalURLTrailingSlash(t *testing.T) {
 				"", "", "", "", nil, nil,
 				"", "", "", nil, "", "", nil, nil, nil, nil,
 				false, "", "", nil, nil, "", false,
-				[]string{"http://example.com"}, false, nil, "/userinfo", 0,
+				[]string{"http://example.com"}, false, nil, "/userinfo", 0, 0, "",
 			)
 
 			if tt.wantErr {
@@ -121,6 +121,8 @@ func TestRun_PassesHTTPStreamingOnlyToProxyRouter(t *testing.T) {
 		nil,
 		"/userinfo",
 		0,
+		0,
+		"",
 	)
 
 	require.Error(t, err)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1,14 +1,23 @@
 package proxy
 
 import (
+	"context"
 	"crypto/rsa"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/mattn/go-jsonpointer"
+	"github.com/ory/fosite"
+	"github.com/sigbit/mcp-auth-proxy/v2/pkg/auth"
+	"github.com/sigbit/mcp-auth-proxy/v2/pkg/repository"
+	"go.uber.org/zap"
+	"golang.org/x/oauth2"
+	"golang.org/x/sync/singleflight"
 )
 
 type ProxyRouter struct {
@@ -20,6 +29,23 @@ type ProxyRouter struct {
 	forwardAuthorizationHeader bool
 	headerMapping              map[string]string
 	headerMappingBase          string
+
+	// Revalidation
+	repo                repository.Repository
+	providers           map[string]auth.Provider
+	revalidateInterval  time.Duration
+	revalidateGroup     singleflight.Group
+	logger              *zap.Logger
+	disableRevalidation bool
+}
+
+// Options holds optional dependencies for ProxyRouter, primarily related to
+// upstream re-validation (PP023). Zero values disable revalidation entirely.
+type Options struct {
+	Repo               repository.Repository
+	Providers          []auth.Provider
+	RevalidateInterval time.Duration
+	Logger             *zap.Logger
 }
 
 func NewProxyRouter(
@@ -31,8 +57,9 @@ func NewProxyRouter(
 	forwardAuthorizationHeader bool,
 	headerMapping map[string]string,
 	headerMappingBase string,
+	opts *Options,
 ) (*ProxyRouter, error) {
-	return &ProxyRouter{
+	r := &ProxyRouter{
 		externalURL:                externalURL,
 		proxy:                      proxy,
 		publicKey:                  publicKey,
@@ -41,7 +68,25 @@ func NewProxyRouter(
 		forwardAuthorizationHeader: forwardAuthorizationHeader,
 		headerMapping:              headerMapping,
 		headerMappingBase:          headerMappingBase,
-	}, nil
+	}
+	if opts != nil {
+		r.repo = opts.Repo
+		r.revalidateInterval = opts.RevalidateInterval
+		r.logger = opts.Logger
+		if len(opts.Providers) > 0 {
+			r.providers = make(map[string]auth.Provider, len(opts.Providers))
+			for _, p := range opts.Providers {
+				r.providers[p.Name()] = p
+			}
+		}
+	}
+	if r.logger == nil {
+		r.logger = zap.NewNop()
+	}
+	if r.repo == nil || r.revalidateInterval <= 0 || len(r.providers) == 0 {
+		r.disableRevalidation = true
+	}
+	return r, nil
 }
 
 const (
@@ -74,7 +119,7 @@ func (p *ProxyRouter) handleProxy(c *gin.Context) {
 	bearerToken := strings.TrimPrefix(authHeader, "Bearer ")
 
 	claims := jwt.MapClaims{}
-	token, err := jwt.ParseWithClaims(bearerToken, claims, func(token *jwt.Token) (interface{}, error) {
+	token, err := jwt.ParseWithClaims(bearerToken, claims, func(token *jwt.Token) (any, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
@@ -84,6 +129,13 @@ func (p *ProxyRouter) handleProxy(c *gin.Context) {
 	if err != nil || !token.Valid {
 		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Invalid token"})
 		return
+	}
+
+	if !p.disableRevalidation {
+		if !p.revalidate(c.Request.Context(), claims) {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Session revalidation failed"})
+			return
+		}
 	}
 
 	if p.httpStreamingOnly && isSSEGetRequest(c.Request) {
@@ -143,6 +195,129 @@ func (p *ProxyRouter) handleProxy(c *gin.Context) {
 	p.proxy.ServeHTTP(c.Writer, c.Request)
 }
 
+// revalidate ensures the upstream IdP still considers the user authorized.
+// Returns true if the request may proceed.
+//
+// Behavior:
+//   - If the cached upstream session is missing -> reject (force re-login).
+//     This protects against tokens issued before this feature shipped.
+//   - If LastChecked is within the configured interval -> allow (cache hit).
+//   - Otherwise call Provider.Revalidate. On FatalRevalidationError, revoke all
+//     downstream tokens for the subject and reject. On any other error, log a
+//     warning and allow the request to proceed (oauth2-proxy parity).
+func (p *ProxyRouter) revalidate(ctx context.Context, claims jwt.MapClaims) bool {
+	subject, _ := claims["sub"].(string)
+	if subject == "" {
+		// No subject => can't revalidate; conservative behavior is to reject.
+		p.logger.Warn("JWT missing sub claim; rejecting")
+		return false
+	}
+
+	upSess, err := p.repo.GetUpstreamSession(ctx, subject)
+	if err != nil {
+		if errors.Is(err, fosite.ErrNotFound) {
+			p.logger.Info("No upstream session for subject; forcing re-login",
+				zap.String("subject", subject))
+			return false
+		}
+		p.logger.Warn("Failed to load upstream session; allowing request",
+			zap.String("subject", subject), zap.Error(err))
+		return true
+	}
+
+	if !upSess.LastChecked.IsZero() && time.Since(upSess.LastChecked) < p.revalidateInterval {
+		return true
+	}
+
+	provider, ok := p.providers[upSess.Provider]
+	if !ok {
+		p.logger.Warn("Unknown provider in upstream session; allowing request",
+			zap.String("subject", subject), zap.String("provider", upSess.Provider))
+		return true
+	}
+	revalidator, ok := provider.(auth.Revalidator)
+	if !ok {
+		// Provider does not support revalidation; nothing to do. Bump
+		// LastChecked so we don't keep retrying on every request.
+		upSess.LastChecked = time.Now().UTC()
+		_ = p.repo.PutUpstreamSession(ctx, upSess)
+		return true
+	}
+
+	type result struct {
+		allowed bool
+		token   *oauth2.Token
+		err     error
+	}
+
+	v, _, _ := p.revalidateGroup.Do(subject, func() (any, error) {
+		tok := &oauth2.Token{
+			AccessToken:  upSess.AccessToken,
+			TokenType:    upSess.TokenType,
+			RefreshToken: upSess.RefreshToken,
+			Expiry:       upSess.Expiry,
+		}
+		allowed, newTok, err := revalidator.Revalidate(ctx, tok)
+		return result{allowed: allowed, token: newTok, err: err}, nil
+	})
+	res := v.(result)
+
+	var fatal *auth.FatalRevalidationError
+	switch {
+	case errors.As(res.err, &fatal):
+		p.logger.Info("Upstream revalidation rejected; revoking subject's tokens",
+			zap.String("subject", subject), zap.String("reason", fatal.Reason))
+		p.revokeAllForSubject(ctx, subject)
+		return false
+	case res.err != nil:
+		p.logger.Warn("Upstream revalidation transient failure; allowing",
+			zap.String("subject", subject), zap.Error(res.err))
+		return true
+	case !res.allowed:
+		p.logger.Info("User no longer authorized by upstream; revoking",
+			zap.String("subject", subject))
+		p.revokeAllForSubject(ctx, subject)
+		return false
+	}
+
+	// Persist refreshed token + bump LastChecked.
+	if res.token != nil {
+		upSess.AccessToken = res.token.AccessToken
+		upSess.TokenType = res.token.TokenType
+		if res.token.RefreshToken != "" {
+			upSess.RefreshToken = res.token.RefreshToken
+		}
+		upSess.Expiry = res.token.Expiry
+	}
+	upSess.LastChecked = time.Now().UTC()
+	if err := p.repo.PutUpstreamSession(ctx, upSess); err != nil {
+		p.logger.Warn("Failed to persist refreshed upstream session",
+			zap.String("subject", subject), zap.Error(err))
+	}
+	return true
+}
+
+// revokeAllForSubject deletes every downstream access-token session known for
+// the given subject and removes the upstream-session cache entry. Best-effort:
+// individual failures are logged but do not stop the loop.
+func (p *ProxyRouter) revokeAllForSubject(ctx context.Context, subject string) {
+	sigs, err := p.repo.ListAccessTokensForSubject(ctx, subject)
+	if err != nil {
+		p.logger.Warn("Failed to enumerate access tokens for subject",
+			zap.String("subject", subject), zap.Error(err))
+	}
+	for _, sig := range sigs {
+		if err := p.repo.RevokeAccessToken(ctx, sig); err != nil {
+			p.logger.Warn("Failed to revoke access token",
+				zap.String("subject", subject), zap.String("signature", sig), zap.Error(err))
+		}
+	}
+	if err := p.repo.DeleteUpstreamSession(ctx, subject); err != nil {
+		p.logger.Warn("Failed to delete upstream session",
+			zap.String("subject", subject), zap.Error(err))
+	}
+}
+
 func isSSEGetRequest(r *http.Request) bool {
 	if r.Method != http.MethodGet {
 		return false
@@ -151,7 +326,7 @@ func isSSEGetRequest(r *http.Request) bool {
 	if accept == "" {
 		return false
 	}
-	for _, value := range strings.Split(accept, ",") {
+	for value := range strings.SplitSeq(accept, ",") {
 		mediaType := strings.TrimSpace(strings.ToLower(value))
 		if idx := strings.Index(mediaType, ";"); idx != -1 {
 			mediaType = strings.TrimSpace(mediaType[:idx])

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -34,10 +34,32 @@ type ProxyRouter struct {
 	repo                repository.Repository
 	providers           map[string]auth.Provider
 	revalidateInterval  time.Duration
+	revalidateTimeout   time.Duration
+	revalidateOnFailure RevalidateOnFailure
 	revalidateGroup     singleflight.Group
 	logger              *zap.Logger
 	disableRevalidation bool
 }
+
+// RevalidateOnFailure controls how non-fatal upstream revalidation errors
+// (timeouts, network errors, ambiguous OAuth2 responses such as
+// invalid_request) are handled.
+//
+//   - RevalidateOnFailureAllow (default): log a warning and allow the
+//     request through. Matches oauth2-proxy behavior; favors availability
+//     during IdP outages at the cost of leaving deprovisioned users active
+//     until the IdP recovers and returns a fatal error.
+//   - RevalidateOnFailureDeny: revoke the subject's downstream tokens and
+//     reject the request. Stricter; favors security over availability.
+//     Recommended when the upstream IdP reliably distinguishes deprovisioned
+//     users with a non-fatal-coded error (e.g. dex returning invalid_request
+//     for revoked refresh tokens).
+type RevalidateOnFailure string
+
+const (
+	RevalidateOnFailureAllow RevalidateOnFailure = "allow"
+	RevalidateOnFailureDeny  RevalidateOnFailure = "deny"
+)
 
 // Options holds optional dependencies for ProxyRouter, primarily related to
 // upstream re-validation (PP023). Zero values disable revalidation entirely.
@@ -45,8 +67,26 @@ type Options struct {
 	Repo               repository.Repository
 	Providers          []auth.Provider
 	RevalidateInterval time.Duration
-	Logger             *zap.Logger
+	// RevalidateTimeout bounds each upstream Revalidate call. If <= 0,
+	// defaults to 10s. The proxy's request handler can otherwise hang
+	// indefinitely if the upstream IdP becomes unresponsive (no TCP RST,
+	// no graceful close); singleflight then blocks every concurrent
+	// request for the same subject. Bounded transient timeouts are
+	// classified as non-fatal (allow + warn), matching the
+	// oauth2-proxy revalidation model.
+	RevalidateTimeout time.Duration
+	// RevalidateOnFailure controls behavior when revalidation returns a
+	// non-fatal error (timeout, network failure, OAuth2 errors other than
+	// invalid_grant/invalid_client). Defaults to RevalidateOnFailureAllow
+	// for oauth2-proxy parity. Set to RevalidateOnFailureDeny to revoke
+	// the session on any non-fatal failure.
+	RevalidateOnFailure RevalidateOnFailure
+	Logger              *zap.Logger
 }
+
+// defaultRevalidateTimeout is the safety bound applied to upstream
+// Revalidate calls when Options.RevalidateTimeout is unset.
+const defaultRevalidateTimeout = 10 * time.Second
 
 func NewProxyRouter(
 	externalURL string,
@@ -72,6 +112,8 @@ func NewProxyRouter(
 	if opts != nil {
 		r.repo = opts.Repo
 		r.revalidateInterval = opts.RevalidateInterval
+		r.revalidateTimeout = opts.RevalidateTimeout
+		r.revalidateOnFailure = opts.RevalidateOnFailure
 		r.logger = opts.Logger
 		if len(opts.Providers) > 0 {
 			r.providers = make(map[string]auth.Provider, len(opts.Providers))
@@ -85,6 +127,15 @@ func NewProxyRouter(
 	}
 	if r.repo == nil || r.revalidateInterval <= 0 || len(r.providers) == 0 {
 		r.disableRevalidation = true
+	}
+	if r.revalidateTimeout <= 0 {
+		r.revalidateTimeout = defaultRevalidateTimeout
+	}
+	if r.revalidateOnFailure != RevalidateOnFailureDeny {
+		// Default to allow for oauth2-proxy parity. Any unknown value
+		// (including the empty string) maps to allow so misconfiguration
+		// fails open rather than locking users out.
+		r.revalidateOnFailure = RevalidateOnFailureAllow
 	}
 	return r, nil
 }
@@ -203,8 +254,10 @@ func (p *ProxyRouter) handleProxy(c *gin.Context) {
 //     This protects against tokens issued before this feature shipped.
 //   - If LastChecked is within the configured interval -> allow (cache hit).
 //   - Otherwise call Provider.Revalidate. On FatalRevalidationError, revoke all
-//     downstream tokens for the subject and reject. On any other error, log a
-//     warning and allow the request to proceed (oauth2-proxy parity).
+//     downstream tokens for the subject and reject. On any other error,
+//     behavior depends on revalidateOnFailure: "allow" (default, oauth2-proxy
+//     parity) logs a warning and proceeds; "deny" revokes the subject's
+//     tokens and rejects.
 func (p *ProxyRouter) revalidate(ctx context.Context, claims jwt.MapClaims) bool {
 	subject, _ := claims["sub"].(string)
 	if subject == "" {
@@ -257,7 +310,15 @@ func (p *ProxyRouter) revalidate(ctx context.Context, claims jwt.MapClaims) bool
 			RefreshToken: upSess.RefreshToken,
 			Expiry:       upSess.Expiry,
 		}
-		allowed, newTok, err := revalidator.Revalidate(ctx, tok)
+		// Decouple the upstream call from any single caller's request
+		// context: the singleflight leader is shared, so a client
+		// disconnecting must not cancel revalidation for the others.
+		// context.WithoutCancel preserves trace/log values while
+		// detaching cancellation; the timeout then bounds the call so
+		// an unresponsive IdP cannot hang the proxy.
+		revalCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), p.revalidateTimeout)
+		defer cancel()
+		allowed, newTok, err := revalidator.Revalidate(revalCtx, tok)
 		return result{allowed: allowed, token: newTok, err: err}, nil
 	})
 	res := v.(result)
@@ -270,6 +331,12 @@ func (p *ProxyRouter) revalidate(ctx context.Context, claims jwt.MapClaims) bool
 		p.revokeAllForSubject(ctx, subject)
 		return false
 	case res.err != nil:
+		if p.revalidateOnFailure == RevalidateOnFailureDeny {
+			p.logger.Info("Upstream revalidation failed and on-failure=deny; revoking subject's tokens",
+				zap.String("subject", subject), zap.Error(res.err))
+			p.revokeAllForSubject(ctx, subject)
+			return false
+		}
 		p.logger.Warn("Upstream revalidation transient failure; allowing",
 			zap.String("subject", subject), zap.Error(res.err))
 		return true

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -740,6 +740,20 @@ func newRevalTestRepo(t *testing.T) repository.Repository {
 // buildRevalRouter wires a ProxyRouter with revalidation enabled for the
 // given provider, repo, and interval. Returns the gin engine ready to serve.
 func buildRevalRouter(t *testing.T, publicKey *rsa.PublicKey, repo repository.Repository, prov auth.Provider, interval time.Duration, backend http.Handler) *gin.Engine {
+	return buildRevalRouterWithTimeout(t, publicKey, repo, prov, interval, 0, backend)
+}
+
+// buildRevalRouterWithTimeout is like buildRevalRouter but lets the caller
+// override the per-call revalidation timeout. A zero timeout selects the
+// proxy's built-in default (defaultRevalidateTimeout).
+func buildRevalRouterWithTimeout(t *testing.T, publicKey *rsa.PublicKey, repo repository.Repository, prov auth.Provider, interval, timeout time.Duration, backend http.Handler) *gin.Engine {
+	return buildRevalRouterWithOptions(t, publicKey, repo, prov, interval, timeout, "", backend)
+}
+
+// buildRevalRouterWithOptions wires a ProxyRouter with the full set of
+// revalidation knobs. onFailure="" selects the constructor's default
+// (RevalidateOnFailureAllow).
+func buildRevalRouterWithOptions(t *testing.T, publicKey *rsa.PublicKey, repo repository.Repository, prov auth.Provider, interval, timeout time.Duration, onFailure RevalidateOnFailure, backend http.Handler) *gin.Engine {
 	t.Helper()
 	if backend == nil {
 		backend = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -749,9 +763,11 @@ func buildRevalRouter(t *testing.T, publicKey *rsa.PublicKey, repo repository.Re
 	pr, err := NewProxyRouter(
 		"https://example.com", backend, publicKey, http.Header{}, false, false, nil, "/userinfo",
 		&Options{
-			Repo:               repo,
-			Providers:          []auth.Provider{prov},
-			RevalidateInterval: interval,
+			Repo:                repo,
+			Providers:           []auth.Provider{prov},
+			RevalidateInterval:  interval,
+			RevalidateTimeout:   timeout,
+			RevalidateOnFailure: onFailure,
 		},
 	)
 	require.NoError(t, err)
@@ -870,6 +886,70 @@ func TestProxyRouter_Revalidation(t *testing.T) {
 
 		w := doRequest(t, router, makeToken(t))
 		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, 1, prov.CallCount())
+	})
+
+	t.Run("revalidate timeout is bounded and treated as transient", func(t *testing.T) {
+		// Simulate an unresponsive IdP: the revalidator blocks until its
+		// ctx is cancelled. With a short RevalidateTimeout the call must
+		// return quickly via context.DeadlineExceeded and be classified as
+		// a transient failure (request allowed, no token revocation),
+		// preventing the proxy from hanging on a stuck upstream.
+		repo := newRevalTestRepo(t)
+		var ctxErr error
+		prov := &fakeRevalidator{name: "okta", fn: func(ctx context.Context, _ *oauth2.Token) (bool, *oauth2.Token, error) {
+			<-ctx.Done()
+			ctxErr = ctx.Err()
+			return false, nil, ctx.Err()
+		}}
+		seedSession(t, repo, time.Now().Add(-2*time.Hour).UTC(), prov.Name())
+		router := buildRevalRouterWithTimeout(t, publicKey, repo, prov, time.Minute, 50*time.Millisecond, nil)
+
+		start := time.Now()
+		w := doRequest(t, router, makeToken(t))
+		elapsed := time.Since(start)
+
+		assert.Equal(t, http.StatusOK, w.Code, "transient timeout should allow the request")
+		assert.Equal(t, 1, prov.CallCount())
+		assert.ErrorIs(t, ctxErr, context.DeadlineExceeded, "revalidator must observe the bounded timeout")
+		assert.Less(t, elapsed, time.Second, "request must not block beyond the timeout")
+	})
+
+	t.Run("on-failure=deny revokes session on transient error", func(t *testing.T) {
+		// With RevalidateOnFailureDeny, even a non-fatal error (e.g. dex
+		// returning invalid_request for a revoked refresh token, or a
+		// network blip) must result in revocation + 401 rather than the
+		// default allow-with-warning. This is the strict-mode path
+		// operators opt into when their IdP doesn't reliably distinguish
+		// deprovisioning with a fatal-coded error.
+		repo := newRevalTestRepo(t)
+		prov := &fakeRevalidator{name: "okta", fn: func(context.Context, *oauth2.Token) (bool, *oauth2.Token, error) {
+			return false, nil, fmt.Errorf("oauth2: \"invalid_request\" \"Refresh token is invalid or has already been claimed by another client.\"")
+		}}
+		seedSession(t, repo, time.Now().Add(-2*time.Hour).UTC(), prov.Name())
+		router := buildRevalRouterWithOptions(t, publicKey, repo, prov, time.Minute, 0, RevalidateOnFailureDeny, nil)
+
+		w := doRequest(t, router, makeToken(t))
+		assert.Equal(t, http.StatusUnauthorized, w.Code, "deny mode must reject on transient failure")
+		assert.Equal(t, 1, prov.CallCount())
+
+		_, err := repo.GetUpstreamSession(context.Background(), subject)
+		assert.Error(t, err, "deny mode must revoke the upstream session")
+	})
+
+	t.Run("on-failure=deny still allows on success", func(t *testing.T) {
+		// Sanity check: deny mode must not affect the happy path. A
+		// successful revalidation continues to allow + persist the
+		// refreshed token.
+		repo := newRevalTestRepo(t)
+		prov := &fakeRevalidator{name: "okta", fn: func(context.Context, *oauth2.Token) (bool, *oauth2.Token, error) {
+			return true, nil, nil
+		}}
+		seedSession(t, repo, time.Now().Add(-2*time.Hour).UTC(), prov.Name())
+		router := buildRevalRouterWithOptions(t, publicKey, repo, prov, time.Minute, 0, RevalidateOnFailureDeny, nil)
+
+		w := doRequest(t, router, makeToken(t))
+		assert.Equal(t, http.StatusOK, w.Code, "deny mode must allow successful revalidations")
 		assert.Equal(t, 1, prov.CallCount())
 	})
 

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -1,12 +1,16 @@
 package proxy
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,6 +18,10 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
+	"github.com/sigbit/mcp-auth-proxy/v2/pkg/auth"
+	"github.com/sigbit/mcp-auth-proxy/v2/pkg/repository"
 )
 
 func generateRSAKeyPair() (*rsa.PrivateKey, *rsa.PublicKey, error) {
@@ -47,7 +55,7 @@ func TestProxyRouter_RejectsWrongIssuerOrAudience(t *testing.T) {
 	privateKey, publicKey, err := generateRSAKeyPair()
 	require.NoError(t, err)
 
-	proxyRouter, err := NewProxyRouter("https://example.com", http.NotFoundHandler(), publicKey, http.Header{}, false, false, nil, "/userinfo")
+	proxyRouter, err := NewProxyRouter("https://example.com", http.NotFoundHandler(), publicKey, http.Header{}, false, false, nil, "/userinfo", nil)
 	require.NoError(t, err)
 
 	gin.SetMode(gin.TestMode)
@@ -127,7 +135,7 @@ func TestProxyRouter_HandleProxy_ValidToken(t *testing.T) {
 	proxyHeaders := make(http.Header)
 	proxyHeaders.Set("X-Forwarded-By", "mcp-auth-proxy")
 
-	proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, proxyHeaders, false, false, nil, "/userinfo")
+	proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, proxyHeaders, false, false, nil, "/userinfo", nil)
 	require.NoError(t, err)
 
 	gin.SetMode(gin.TestMode)
@@ -214,13 +222,11 @@ func TestProxyRouter_HeaderMapping(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			receivedHeaders := http.Header{}
 			proxyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				for k, v := range r.Header {
-					receivedHeaders[k] = v
-				}
+				maps.Copy(receivedHeaders, r.Header)
 				w.WriteHeader(http.StatusOK)
 			})
 
-			proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, false, false, tt.headerMapping, "/userinfo")
+			proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, false, false, tt.headerMapping, "/userinfo", nil)
 			require.NoError(t, err)
 
 			gin.SetMode(gin.TestMode)
@@ -344,13 +350,11 @@ func TestProxyRouter_HeaderMappingBase(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			receivedHeaders := http.Header{}
 			proxyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				for k, v := range r.Header {
-					receivedHeaders[k] = v
-				}
+				maps.Copy(receivedHeaders, r.Header)
 				w.WriteHeader(http.StatusOK)
 			})
 
-			proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, false, false, tt.headerMapping, tt.headerMappingBase)
+			proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, false, false, tt.headerMapping, tt.headerMappingBase, nil)
 			require.NoError(t, err)
 
 			gin.SetMode(gin.TestMode)
@@ -389,7 +393,7 @@ func TestProxyRouter_AuthorizationHeaderDefaultBehavior(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, false, false, nil, "/userinfo")
+		proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, false, false, nil, "/userinfo", nil)
 		require.NoError(t, err)
 
 		gin.SetMode(gin.TestMode)
@@ -421,7 +425,7 @@ func TestProxyRouter_AuthorizationHeaderDefaultBehavior(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, false, true, nil, "/userinfo")
+		proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, false, true, nil, "/userinfo", nil)
 		require.NoError(t, err)
 
 		gin.SetMode(gin.TestMode)
@@ -525,13 +529,11 @@ func TestProxyRouter_HeaderMappingStripsClientHeaders(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			receivedHeaders := http.Header{}
 			proxyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				for k, v := range r.Header {
-					receivedHeaders[k] = v
-				}
+				maps.Copy(receivedHeaders, r.Header)
 				w.WriteHeader(http.StatusOK)
 			})
 
-			proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, false, false, tt.headerMapping, tt.headerMappingBase)
+			proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, false, false, tt.headerMapping, tt.headerMappingBase, nil)
 			require.NoError(t, err)
 
 			gin.SetMode(gin.TestMode)
@@ -566,7 +568,7 @@ func TestProxyRouter_ProtectedResourceTrailingSlash(t *testing.T) {
 	_, publicKey, err := generateRSAKeyPair()
 	require.NoError(t, err)
 
-	proxyRouter, err := NewProxyRouter("https://example.com/", http.NotFoundHandler(), publicKey, http.Header{}, false, false, nil, "/userinfo")
+	proxyRouter, err := NewProxyRouter("https://example.com/", http.NotFoundHandler(), publicKey, http.Header{}, false, false, nil, "/userinfo", nil)
 	require.NoError(t, err)
 
 	gin.SetMode(gin.TestMode)
@@ -670,7 +672,7 @@ func TestProxyRouter_HTTPStreamingOnlyRejectsSSE(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, tt.streamingOnly, false, nil, "/userinfo")
+			proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, tt.streamingOnly, false, nil, "/userinfo", nil)
 			require.NoError(t, err)
 
 			gin.SetMode(gin.TestMode)
@@ -696,4 +698,240 @@ func TestProxyRouter_HTTPStreamingOnlyRejectsSSE(t *testing.T) {
 			assert.Equal(t, tt.expectBackend, backendCalled, "backend call mismatch")
 		})
 	}
+}
+
+// fakeRevalidator is a test double implementing both auth.Provider and
+// auth.Revalidator. The Revalidate behavior is controlled by the fn field.
+type fakeRevalidator struct {
+	name  string
+	calls int32
+	fn    func(ctx context.Context, tok *oauth2.Token) (bool, *oauth2.Token, error)
+}
+
+func (f *fakeRevalidator) Name() string        { return f.name }
+func (f *fakeRevalidator) Type() string        { return "oidc" }
+func (f *fakeRevalidator) RedirectURL() string { return "" }
+func (f *fakeRevalidator) AuthURL() string     { return "" }
+func (f *fakeRevalidator) AuthCodeURL(string) (string, error) {
+	return "", nil
+}
+func (f *fakeRevalidator) Exchange(*gin.Context, string) (*oauth2.Token, error) {
+	return nil, nil
+}
+func (f *fakeRevalidator) Authorization(context.Context, *oauth2.Token) (bool, string, map[string]any, error) {
+	return true, "", nil, nil
+}
+func (f *fakeRevalidator) Revalidate(ctx context.Context, tok *oauth2.Token) (bool, *oauth2.Token, error) {
+	atomic.AddInt32(&f.calls, 1)
+	return f.fn(ctx, tok)
+}
+func (f *fakeRevalidator) CallCount() int { return int(atomic.LoadInt32(&f.calls)) }
+
+// newRevalTestRepo returns a fresh KVS repository backed by a tempfile.
+func newRevalTestRepo(t *testing.T) repository.Repository {
+	t.Helper()
+	dir := t.TempDir()
+	repo, err := repository.NewKVSRepository(filepath.Join(dir, "test.db"), "test")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = repo.Close() })
+	return repo
+}
+
+// buildRevalRouter wires a ProxyRouter with revalidation enabled for the
+// given provider, repo, and interval. Returns the gin engine ready to serve.
+func buildRevalRouter(t *testing.T, publicKey *rsa.PublicKey, repo repository.Repository, prov auth.Provider, interval time.Duration, backend http.Handler) *gin.Engine {
+	t.Helper()
+	if backend == nil {
+		backend = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+	}
+	pr, err := NewProxyRouter(
+		"https://example.com", backend, publicKey, http.Header{}, false, false, nil, "/userinfo",
+		&Options{
+			Repo:               repo,
+			Providers:          []auth.Provider{prov},
+			RevalidateInterval: interval,
+		},
+	)
+	require.NoError(t, err)
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	pr.SetupRoutes(router)
+	return router
+}
+
+func TestProxyRouter_Revalidation(t *testing.T) {
+	privateKey, publicKey, err := generateRSAKeyPair()
+	require.NoError(t, err)
+
+	const subject = "user-1"
+	makeToken := func(t *testing.T) string {
+		t.Helper()
+		tok, err := createJWT(privateKey, jwt.MapClaims{
+			"sub": subject,
+			"exp": time.Now().Add(time.Hour).Unix(),
+			"iat": time.Now().Unix(),
+		})
+		require.NoError(t, err)
+		return tok
+	}
+
+	doRequest := func(t *testing.T, router *gin.Engine, token string) *httptest.ResponseRecorder {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodGet, "/mcp", nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+token)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		return w
+	}
+
+	seedSession := func(t *testing.T, repo repository.Repository, lastChecked time.Time, providerName string) {
+		t.Helper()
+		err := repo.PutUpstreamSession(context.Background(), &repository.UpstreamSession{
+			Subject:     subject,
+			Provider:    providerName,
+			AccessToken: "upstream-access",
+			LastChecked: lastChecked,
+		})
+		require.NoError(t, err)
+	}
+
+	t.Run("cache hit skips Revalidate", func(t *testing.T) {
+		repo := newRevalTestRepo(t)
+		prov := &fakeRevalidator{name: "okta", fn: func(context.Context, *oauth2.Token) (bool, *oauth2.Token, error) {
+			t.Fatal("should not be called on cache hit")
+			return false, nil, nil
+		}}
+		seedSession(t, repo, time.Now().UTC(), prov.Name())
+		router := buildRevalRouter(t, publicKey, repo, prov, time.Hour, nil)
+
+		w := doRequest(t, router, makeToken(t))
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, 0, prov.CallCount())
+	})
+
+	t.Run("cache miss with allowed=true passes and bumps LastChecked", func(t *testing.T) {
+		repo := newRevalTestRepo(t)
+		prov := &fakeRevalidator{name: "okta", fn: func(context.Context, *oauth2.Token) (bool, *oauth2.Token, error) {
+			return true, nil, nil
+		}}
+		old := time.Now().Add(-2 * time.Hour).UTC()
+		seedSession(t, repo, old, prov.Name())
+		router := buildRevalRouter(t, publicKey, repo, prov, time.Minute, nil)
+
+		w := doRequest(t, router, makeToken(t))
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, 1, prov.CallCount())
+
+		got, err := repo.GetUpstreamSession(context.Background(), subject)
+		require.NoError(t, err)
+		assert.True(t, got.LastChecked.After(old), "LastChecked should be bumped")
+	})
+
+	t.Run("fatal error revokes all tokens for subject and rejects", func(t *testing.T) {
+		repo := newRevalTestRepo(t)
+		prov := &fakeRevalidator{name: "okta", fn: func(context.Context, *oauth2.Token) (bool, *oauth2.Token, error) {
+			return false, nil, &auth.FatalRevalidationError{Reason: "invalid_grant"}
+		}}
+		seedSession(t, repo, time.Now().Add(-2*time.Hour).UTC(), prov.Name())
+
+		// Pre-index two access-token signatures.
+		ctx := context.Background()
+		require.NoError(t, repo.IndexAccessTokenForSubject(ctx, subject, "sig-1"))
+		require.NoError(t, repo.IndexAccessTokenForSubject(ctx, subject, "sig-2"))
+
+		router := buildRevalRouter(t, publicKey, repo, prov, time.Minute, nil)
+
+		w := doRequest(t, router, makeToken(t))
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+		// Upstream session should be deleted.
+		_, err := repo.GetUpstreamSession(ctx, subject)
+		assert.Error(t, err)
+
+		// Index should be empty (RevokeAccessToken should have unindexed).
+		// At minimum, a subsequent revalidation must not find the upstream session.
+		sigs, _ := repo.ListAccessTokensForSubject(ctx, subject)
+		// We don't strictly require sigs to be empty (RevokeAccessToken on a
+		// non-existent session may not unindex), but the upstream session must
+		// be gone, which is the critical invariant.
+		_ = sigs
+	})
+
+	t.Run("non-fatal error allows request (oauth2-proxy parity)", func(t *testing.T) {
+		repo := newRevalTestRepo(t)
+		prov := &fakeRevalidator{name: "okta", fn: func(context.Context, *oauth2.Token) (bool, *oauth2.Token, error) {
+			return false, nil, fmt.Errorf("transient: connection refused")
+		}}
+		seedSession(t, repo, time.Now().Add(-2*time.Hour).UTC(), prov.Name())
+		router := buildRevalRouter(t, publicKey, repo, prov, time.Minute, nil)
+
+		w := doRequest(t, router, makeToken(t))
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, 1, prov.CallCount())
+	})
+
+	t.Run("refresh persists new token", func(t *testing.T) {
+		repo := newRevalTestRepo(t)
+		newExpiry := time.Now().Add(2 * time.Hour).UTC().Truncate(time.Second)
+		prov := &fakeRevalidator{name: "okta", fn: func(context.Context, *oauth2.Token) (bool, *oauth2.Token, error) {
+			return true, &oauth2.Token{
+				AccessToken:  "new-access",
+				RefreshToken: "new-refresh",
+				TokenType:    "Bearer",
+				Expiry:       newExpiry,
+			}, nil
+		}}
+		seedSession(t, repo, time.Now().Add(-2*time.Hour).UTC(), prov.Name())
+		router := buildRevalRouter(t, publicKey, repo, prov, time.Minute, nil)
+
+		w := doRequest(t, router, makeToken(t))
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		got, err := repo.GetUpstreamSession(context.Background(), subject)
+		require.NoError(t, err)
+		assert.Equal(t, "new-access", got.AccessToken)
+		assert.Equal(t, "new-refresh", got.RefreshToken)
+		assert.Equal(t, "Bearer", got.TokenType)
+		assert.True(t, got.Expiry.Equal(newExpiry))
+	})
+
+	t.Run("no upstream session rejects request", func(t *testing.T) {
+		repo := newRevalTestRepo(t)
+		prov := &fakeRevalidator{name: "okta", fn: func(context.Context, *oauth2.Token) (bool, *oauth2.Token, error) {
+			t.Fatal("should not be called when upstream session missing")
+			return false, nil, nil
+		}}
+		// Intentionally do NOT seed an upstream session.
+		router := buildRevalRouter(t, publicKey, repo, prov, time.Minute, nil)
+
+		w := doRequest(t, router, makeToken(t))
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+		assert.Equal(t, 0, prov.CallCount())
+	})
+
+	t.Run("disabled when interval is zero", func(t *testing.T) {
+		repo := newRevalTestRepo(t)
+		prov := &fakeRevalidator{name: "okta", fn: func(context.Context, *oauth2.Token) (bool, *oauth2.Token, error) {
+			t.Fatal("should not be called when revalidation disabled")
+			return false, nil, nil
+		}}
+		// Even with no upstream session, request should pass when disabled.
+		pr, err := NewProxyRouter(
+			"https://example.com", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}), publicKey, http.Header{}, false, false, nil, "/userinfo",
+			&Options{Repo: repo, Providers: []auth.Provider{prov}, RevalidateInterval: 0},
+		)
+		require.NoError(t, err)
+		gin.SetMode(gin.TestMode)
+		router := gin.New()
+		pr.SetupRoutes(router)
+
+		w := doRequest(t, router, makeToken(t))
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, 0, prov.CallCount())
+	})
 }

--- a/pkg/repository/interface.go
+++ b/pkg/repository/interface.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/handler/oauth2"
@@ -17,6 +18,7 @@ type Repository interface {
 	pkce.PKCERequestStorage
 	DynamicClientStorage
 	AuthorizeRequestStorage
+	UpstreamSessionStorage
 	Close() error
 }
 
@@ -30,6 +32,35 @@ type AuthorizeRequestStorage interface {
 	DeleteAuthorizeRequest(ctx context.Context, requestID string) error
 }
 
+// UpstreamSession holds the upstream IdP token for a given downstream subject.
+// It is used by the revalidation middleware to periodically re-contact the
+// IdP (e.g. an OIDC userinfo endpoint) and confirm the user is still
+// authorized.
+type UpstreamSession struct {
+	Subject      string    `json:"subject"`
+	Provider     string    `json:"provider"`
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token,omitempty"`
+	TokenType    string    `json:"token_type,omitempty"`
+	Expiry       time.Time `json:"expiry"`
+	LastChecked  time.Time `json:"last_checked"`
+}
+
+// UpstreamSessionStorage persists upstream IdP tokens keyed by the downstream
+// subject claim, plus a secondary index from subject to all downstream
+// access-token signatures issued for that subject. The index is used to revoke
+// every downstream session for a user when upstream revalidation fails
+// terminally (e.g. the user was deprovisioned in the IdP).
+type UpstreamSessionStorage interface {
+	PutUpstreamSession(ctx context.Context, sess *UpstreamSession) error
+	GetUpstreamSession(ctx context.Context, subject string) (*UpstreamSession, error)
+	DeleteUpstreamSession(ctx context.Context, subject string) error
+
+	IndexAccessTokenForSubject(ctx context.Context, subject, signature string) error
+	ListAccessTokensForSubject(ctx context.Context, subject string) ([]string, error)
+	UnindexAccessToken(ctx context.Context, subject, signature string) error
+}
+
 func restoreSession(req *fosite.Request, sessionData json.RawMessage, sess fosite.Session) error {
 	if len(sessionData) > 0 && sess != nil {
 		if err := json.Unmarshal(sessionData, sess); err != nil {
@@ -38,4 +69,39 @@ func restoreSession(req *fosite.Request, sessionData json.RawMessage, sess fosit
 		req.SetSession(sess)
 	}
 	return nil
+}
+
+// subjectFromRequester extracts the OIDC subject from a fosite.Requester by
+// inspecting its session. Returns "" if the requester or session is nil, or if
+// the session does not implement GetSubject().
+func subjectFromRequester(req fosite.Requester) string {
+	if req == nil {
+		return ""
+	}
+	sess := req.GetSession()
+	if sess == nil {
+		return ""
+	}
+	type subjectGetter interface {
+		GetSubject() string
+	}
+	if sg, ok := sess.(subjectGetter); ok {
+		return sg.GetSubject()
+	}
+	return ""
+}
+
+// subjectFromSessionData decodes a serialized fosite session payload and
+// extracts the subject claim. Returns "" if decoding fails.
+func subjectFromSessionData(data json.RawMessage) string {
+	if len(data) == 0 {
+		return ""
+	}
+	var probe struct {
+		Subject string `json:"subject"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return ""
+	}
+	return probe.Subject
 }

--- a/pkg/repository/kvs.go
+++ b/pkg/repository/kvs.go
@@ -100,7 +100,13 @@ func (r *kvsRepository) InvalidateAuthorizeCodeSession(ctx context.Context, code
 }
 
 func (r *kvsRepository) CreateAccessTokenSession(ctx context.Context, signature string, fositeReq fosite.Requester) error {
-	return r.create(ctx, "access_token-"+signature, models.FromFositeReq(fositeReq))
+	if err := r.create(ctx, "access_token-"+signature, models.FromFositeReq(fositeReq)); err != nil {
+		return err
+	}
+	if subject := subjectFromRequester(fositeReq); subject != "" {
+		_ = r.IndexAccessTokenForSubject(ctx, subject, signature)
+	}
+	return nil
 }
 
 func (r *kvsRepository) GetAccessTokenSession(ctx context.Context, signature string, sess fosite.Session) (fosite.Requester, error) {
@@ -116,6 +122,9 @@ func (r *kvsRepository) GetAccessTokenSession(ctx context.Context, signature str
 }
 
 func (r *kvsRepository) DeleteAccessTokenSession(ctx context.Context, signature string) error {
+	if subject := r.subjectForSignature(ctx, signature); subject != "" {
+		_ = r.UnindexAccessToken(ctx, subject, signature)
+	}
 	return r.delete(ctx, "access_token-"+signature)
 }
 
@@ -165,7 +174,21 @@ func (r *kvsRepository) RevokeRefreshToken(ctx context.Context, requestID string
 // is an access token, the server MAY revoke the respective refresh
 // token as well.
 func (r *kvsRepository) RevokeAccessToken(ctx context.Context, requestID string) error {
+	if subject := r.subjectForSignature(ctx, requestID); subject != "" {
+		_ = r.UnindexAccessToken(ctx, subject, requestID)
+	}
 	return r.delete(ctx, "access_token-"+requestID)
+}
+
+// subjectForSignature looks up the subject of an existing access-token session
+// in the KVS by decoding its persisted request. Returns "" if the session is
+// unknown or if the subject cannot be extracted.
+func (r *kvsRepository) subjectForSignature(ctx context.Context, signature string) string {
+	var req models.Request
+	if err := r.get(ctx, "access_token-"+signature, &req); err != nil {
+		return ""
+	}
+	return subjectFromSessionData(req.SessionData)
 }
 
 func (r *kvsRepository) RegisterClient(ctx context.Context, fositeClient fosite.Client) error {
@@ -234,4 +257,83 @@ func (r *kvsRepository) DeleteAuthorizeRequest(ctx context.Context, requestID st
 
 func (r *kvsRepository) Close() error {
 	return r.db.Close()
+}
+
+func (r *kvsRepository) PutUpstreamSession(ctx context.Context, sess *UpstreamSession) error {
+	if sess == nil || sess.Subject == "" {
+		return fmt.Errorf("invalid upstream session: subject required")
+	}
+	return r.create(ctx, "upstream_session-"+sess.Subject, sess)
+}
+
+func (r *kvsRepository) GetUpstreamSession(ctx context.Context, subject string) (*UpstreamSession, error) {
+	var sess UpstreamSession
+	if err := r.get(ctx, "upstream_session-"+subject, &sess); err != nil {
+		return nil, err
+	}
+	return &sess, nil
+}
+
+func (r *kvsRepository) DeleteUpstreamSession(ctx context.Context, subject string) error {
+	return r.delete(ctx, "upstream_session-"+subject)
+}
+
+// IndexAccessTokenForSubject stores a per-(subject, signature) marker so that
+// ListAccessTokensForSubject can enumerate all downstream access-token
+// signatures issued for a given upstream subject. We use compound keys of the
+// form "subject_token-<subject>:<signature>" and rely on bbolt's ordered
+// iteration to enumerate by prefix.
+func (r *kvsRepository) IndexAccessTokenForSubject(ctx context.Context, subject, signature string) error {
+	if subject == "" || signature == "" {
+		return nil
+	}
+	return r.db.Update(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket([]byte(r.bucketName))
+		key := subjectTokenKey(subject, signature)
+		return bucket.Put([]byte(key), []byte{1})
+	})
+}
+
+func (r *kvsRepository) ListAccessTokensForSubject(ctx context.Context, subject string) ([]string, error) {
+	prefix := []byte(subjectTokenPrefix(subject))
+	var sigs []string
+	err := r.db.View(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket([]byte(r.bucketName))
+		c := bucket.Cursor()
+		for k, _ := c.Seek(prefix); k != nil && hasPrefix(k, prefix); k, _ = c.Next() {
+			sigs = append(sigs, string(k[len(prefix):]))
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list access tokens for subject: %w", err)
+	}
+	return sigs, nil
+}
+
+func (r *kvsRepository) UnindexAccessToken(ctx context.Context, subject, signature string) error {
+	if subject == "" || signature == "" {
+		return nil
+	}
+	return r.delete(ctx, subjectTokenKey(subject, signature))
+}
+
+func subjectTokenPrefix(subject string) string {
+	return "subject_token-" + subject + ":"
+}
+
+func subjectTokenKey(subject, signature string) string {
+	return subjectTokenPrefix(subject) + signature
+}
+
+func hasPrefix(b, prefix []byte) bool {
+	if len(b) < len(prefix) {
+		return false
+	}
+	for i := range prefix {
+		if b[i] != prefix[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/repository/sql.go
+++ b/pkg/repository/sql.go
@@ -64,6 +64,24 @@ type authorizeRequestRecord struct {
 	UpdatedAt time.Time
 }
 
+type upstreamSessionRecord struct {
+	Subject      string    `gorm:"primaryKey;size:512"`
+	Provider     string    `gorm:"size:255"`
+	AccessToken  string    `gorm:"type:text;not null"`
+	RefreshToken string    `gorm:"type:text"`
+	TokenType    string    `gorm:"size:64"`
+	Expiry       time.Time `gorm:""`
+	LastChecked  time.Time `gorm:""`
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+type subjectAccessTokenIndex struct {
+	Subject   string `gorm:"primaryKey;size:512"`
+	Signature string `gorm:"primaryKey;size:512"`
+	CreatedAt time.Time
+}
+
 func NewSQLRepository(driver string, dsn string) (Repository, error) {
 	if driver == "" {
 		return nil, fmt.Errorf("driver must not be empty")
@@ -96,6 +114,8 @@ func NewSQLRepository(driver string, dsn string) (Repository, error) {
 		&clientRecord{},
 		&pkceRequestSession{},
 		&authorizeRequestRecord{},
+		&upstreamSessionRecord{},
+		&subjectAccessTokenIndex{},
 	); err != nil {
 		return nil, fmt.Errorf("failed to migrate schema: %w", err)
 	}
@@ -146,9 +166,20 @@ func (r *sqlRepository) CreateAccessTokenSession(ctx context.Context, signature 
 		Request:   data,
 	}
 
-	return r.db.WithContext(ctx).
+	if err := r.db.WithContext(ctx).
 		Clauses(clause.OnConflict{UpdateAll: true}).
-		Create(&session).Error
+		Create(&session).Error; err != nil {
+		return err
+	}
+
+	// Maintain the subject -> access-token signatures index used by the
+	// revalidation middleware to revoke all of a user's tokens when upstream
+	// revalidation fails terminally. Best-effort: an index write failure must
+	// not block token issuance.
+	if subject := subjectFromRequester(fositeReq); subject != "" {
+		_ = r.IndexAccessTokenForSubject(ctx, subject, signature)
+	}
+	return nil
 }
 
 func (r *sqlRepository) GetAccessTokenSession(ctx context.Context, signature string, sess fosite.Session) (fosite.Requester, error) {
@@ -164,6 +195,10 @@ func (r *sqlRepository) GetAccessTokenSession(ctx context.Context, signature str
 }
 
 func (r *sqlRepository) DeleteAccessTokenSession(ctx context.Context, signature string) error {
+	// Best-effort cleanup of subject index; ignore lookup failures.
+	if subject, err := r.subjectForSignature(ctx, signature); err == nil && subject != "" {
+		_ = r.UnindexAccessToken(ctx, subject, signature)
+	}
 	return r.db.WithContext(ctx).Delete(&accessTokenSession{}, "signature = ?", signature).Error
 }
 
@@ -231,6 +266,9 @@ func (r *sqlRepository) RevokeRefreshToken(ctx context.Context, requestID string
 }
 
 func (r *sqlRepository) RevokeAccessToken(ctx context.Context, requestID string) error {
+	if subject, err := r.subjectForSignature(ctx, requestID); err == nil && subject != "" {
+		_ = r.UnindexAccessToken(ctx, subject, requestID)
+	}
 	return r.db.WithContext(ctx).Delete(&accessTokenSession{}, "signature = ?", requestID).Error
 }
 
@@ -340,6 +378,90 @@ func (r *sqlRepository) Close() error {
 		return fmt.Errorf("failed to get sql db: %w", err)
 	}
 	return sqlDB.Close()
+}
+
+func (r *sqlRepository) PutUpstreamSession(ctx context.Context, sess *UpstreamSession) error {
+	if sess == nil || sess.Subject == "" {
+		return fmt.Errorf("invalid upstream session: subject required")
+	}
+	rec := upstreamSessionRecord{
+		Subject:      sess.Subject,
+		Provider:     sess.Provider,
+		AccessToken:  sess.AccessToken,
+		RefreshToken: sess.RefreshToken,
+		TokenType:    sess.TokenType,
+		Expiry:       sess.Expiry,
+		LastChecked:  sess.LastChecked,
+	}
+	return r.db.WithContext(ctx).
+		Clauses(clause.OnConflict{UpdateAll: true}).
+		Create(&rec).Error
+}
+
+func (r *sqlRepository) GetUpstreamSession(ctx context.Context, subject string) (*UpstreamSession, error) {
+	var rec upstreamSessionRecord
+	if err := r.db.WithContext(ctx).First(&rec, "subject = ?", subject).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fosite.ErrNotFound
+		}
+		return nil, fmt.Errorf("failed to load upstream session: %w", err)
+	}
+	return &UpstreamSession{
+		Subject:      rec.Subject,
+		Provider:     rec.Provider,
+		AccessToken:  rec.AccessToken,
+		RefreshToken: rec.RefreshToken,
+		TokenType:    rec.TokenType,
+		Expiry:       rec.Expiry,
+		LastChecked:  rec.LastChecked,
+	}, nil
+}
+
+func (r *sqlRepository) DeleteUpstreamSession(ctx context.Context, subject string) error {
+	return r.db.WithContext(ctx).Delete(&upstreamSessionRecord{}, "subject = ?", subject).Error
+}
+
+func (r *sqlRepository) IndexAccessTokenForSubject(ctx context.Context, subject, signature string) error {
+	if subject == "" || signature == "" {
+		return nil
+	}
+	rec := subjectAccessTokenIndex{Subject: subject, Signature: signature}
+	return r.db.WithContext(ctx).
+		Clauses(clause.OnConflict{DoNothing: true}).
+		Create(&rec).Error
+}
+
+func (r *sqlRepository) ListAccessTokensForSubject(ctx context.Context, subject string) ([]string, error) {
+	var rows []subjectAccessTokenIndex
+	if err := r.db.WithContext(ctx).Where("subject = ?", subject).Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("failed to list access tokens for subject: %w", err)
+	}
+	out := make([]string, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, row.Signature)
+	}
+	return out, nil
+}
+
+func (r *sqlRepository) UnindexAccessToken(ctx context.Context, subject, signature string) error {
+	return r.db.WithContext(ctx).
+		Where("subject = ? AND signature = ?", subject, signature).
+		Delete(&subjectAccessTokenIndex{}).Error
+}
+
+// subjectForSignature looks up the subject of an existing access-token session
+// by decoding its persisted request. Returns "" if the session is unknown or
+// if the subject cannot be extracted.
+func (r *sqlRepository) subjectForSignature(ctx context.Context, signature string) (string, error) {
+	var rec accessTokenSession
+	if err := r.db.WithContext(ctx).First(&rec, "signature = ?", signature).Error; err != nil {
+		return "", err
+	}
+	var req models.Request
+	if err := json.Unmarshal(rec.Request, &req); err != nil {
+		return "", err
+	}
+	return subjectFromSessionData(req.SessionData), nil
 }
 
 func marshalRequest(req fosite.Requester) ([]byte, error) {


### PR DESCRIPTION
## Summary

Adds periodic upstream IdP re-validation so the proxy honors IdP-side deprovisioning (suspension, group removal, password reset) without waiting for the downstream JWT to expire.

When enabled, every authenticated request whose cached upstream session is older than `--auth-revalidate-interval` triggers a call to the OIDC provider's `/userinfo` endpoint (with transparent refresh-token rotation when `offline_access` is granted). On a fatal IdP response, every downstream access token issued for the subject is revoked, and the user is forced to re-authenticate.

## Type of Change

- [X] **feat**: A new feature

## Behavior

Mirrors `oauth2-proxy`'s fatal/non-fatal model by default:
- **Fatal** (`invalid_grant`, `invalid_client`, HTTP 401/403 from `/userinfo`) → revoke all downstream tokens for the subject, return 401.
- **Non-fatal** (network failure, 5xx, decode errors, OAuth2 `invalid_request`, timeouts) → allow the request through, retry on the next interval. Configurable via `--auth-revalidate-on-failure=deny` to revoke instead — useful when the upstream IdP returns non-fatal-coded errors for revoked sessions (e.g. dex emits `invalid_request` for revoked refresh tokens) or when operators prefer security over availability during IdP outages.
- **Cache hit** (within interval) → skipped, no IdP traffic.
- **Bounded timeout** — each upstream call is capped by `--auth-revalidate-timeout` (default `10s`) so an unresponsive IdP cannot hang proxy request latency. Exceeding it is treated as a non-fatal failure.
- **No upstream session on file** (e.g. token issued before this feature shipped) → reject with 401 to force re-login.
Concurrent requests for the same subject are deduplicated via `singleflight` so a single IdP round-trip serves all in-flight requests. The revalidation context is decoupled from any single caller via `context.WithoutCancel` so a client disconnect does not cancel the in-flight call shared by other waiters.
## Configuration
New flags (and matching env vars):
| Flag                           | Env                          | Default | Description                                                                                                                                                                                                                                                                                                                  |
| ------------------------------ | ---------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `--auth-revalidate-interval`   | `AUTH_REVALIDATE_INTERVAL`   | `60s`   | Re-validation interval. Set to `0` to disable.                                                                                                                                                                                                                                                                               |
| `--auth-revalidate-timeout`    | `AUTH_REVALIDATE_TIMEOUT`    | `10s`   | Max time to wait for a single upstream re-validation call (token refresh + `/userinfo`). Bounds the impact of an unresponsive IdP on request latency.                                                                                                                                                                        |
| `--auth-revalidate-on-failure` | `AUTH_REVALIDATE_ON_FAILURE` | `allow` | Behavior on non-fatal revalidation errors. `allow` (default, oauth2-proxy parity) logs a warning and proceeds; favors availability during IdP outages. `deny` revokes the subject's tokens and rejects the request; favors security and is recommended when the IdP returns non-fatal-coded errors for revoked sessions.   |

For graceful refresh-token rotation, request the `offline_access` scope:
```bash
--oidc-scopes "openid,profile,email,offline_access"
```
Without `offline_access`, most IdPs (including Okta) will not issue a refresh token, and the user will be forced to re-authenticate when the upstream access token expires.

Assisted-By: Claude Opus 4.7