### PR TITLE
feat: Add Subject claim to proxy logs.

### DIFF
--- a/pkg/mcp-proxy/main.go
+++ b/pkg/mcp-proxy/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sigbit/mcp-auth-proxy/v2/pkg/tlsreload"
 	"github.com/sigbit/mcp-auth-proxy/v2/pkg/utils"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/acme/autocert"
 	"golang.org/x/crypto/bcrypt"
@@ -313,7 +314,18 @@ func Run(
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})
 	})
 
-	router.Use(ginzap.Ginzap(logger, time.RFC3339, true))
+	router.Use(ginzap.GinzapWithConfig(logger, &ginzap.Config{
+		TimeFormat:   time.RFC3339,
+		UTC:          true,
+		DefaultLevel: zapcore.InfoLevel,
+		Context: func(c *gin.Context) []zapcore.Field {
+			if subject, exists := c.Get("subject"); exists {
+				return []zapcore.Field{zap.Any("subject", subject)}
+			}
+			return nil
+		},
+	}))
+
 	router.Use(ginzap.CustomRecoveryWithZap(logger, true, func(c *gin.Context, err any) {
 		if err == http.ErrAbortHandler {
 			c.Abort()

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -86,6 +86,12 @@ func (p *ProxyRouter) handleProxy(c *gin.Context) {
 		return
 	}
 
+	if subject, _ := claims.GetSubject(); subject != "" {
+		c.Set("subject", subject)
+	} else {
+		c.Set("subject", "null")
+	}
+
 	if p.httpStreamingOnly && isSSEGetRequest(c.Request) {
 		c.AbortWithStatusJSON(http.StatusMethodNotAllowed, gin.H{"error": "SSE (GET) streaming is not supported by this backend; use POST-based HTTP streaming instead"})
 		return

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -88,8 +88,6 @@ func (p *ProxyRouter) handleProxy(c *gin.Context) {
 
 	if subject, _ := claims.GetSubject(); subject != "" {
 		c.Set("subject", subject)
-	} else {
-		c.Set("subject", "null")
 	}
 
 	if p.httpStreamingOnly && isSSEGetRequest(c.Request) {

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -697,3 +697,72 @@ func TestProxyRouter_HTTPStreamingOnlyRejectsSSE(t *testing.T) {
 		})
 	}
 }
+
+func TestProxyRouter_SetsSubjectInContext(t *testing.T) {
+	privateKey, publicKey, err := generateRSAKeyPair()
+	require.NoError(t, err)
+
+	cases := []struct {
+		name            string
+		claims          jwt.MapClaims
+		expectedSubject string
+	}{
+		{
+			name: "sub claim is set in context",
+			claims: jwt.MapClaims{
+				"sub": "user-123",
+				"exp": time.Now().Add(time.Hour).Unix(),
+				"iat": time.Now().Unix(),
+			},
+			expectedSubject: "user-123",
+		},
+		{
+			name: "missing sub claim sets null",
+			claims: jwt.MapClaims{
+				"exp": time.Now().Add(time.Hour).Unix(),
+				"iat": time.Now().Unix(),
+			},
+			expectedSubject: "null",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedSubject string
+			var capturedExists bool
+
+			proxyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			proxyRouter, err := NewProxyRouter("https://example.com", proxyHandler, publicKey, http.Header{}, false, false, nil, "/userinfo")
+			require.NoError(t, err)
+
+			gin.SetMode(gin.TestMode)
+			router := gin.New()
+			router.Use(func(c *gin.Context) {
+				c.Next()
+				val, exists := c.Get("subject")
+				capturedExists = exists
+				if exists {
+					capturedSubject, _ = val.(string)
+				}
+			})
+			proxyRouter.SetupRoutes(router)
+
+			token, err := createJWT(privateKey, tt.claims)
+			require.NoError(t, err)
+
+			req, err := http.NewRequest(http.MethodGet, "/test", nil)
+			require.NoError(t, err)
+			req.Header.Set("Authorization", "Bearer "+token)
+
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.True(t, capturedExists)
+			assert.Equal(t, tt.expectedSubject, capturedSubject)
+		})
+	}
+}

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -703,9 +703,10 @@ func TestProxyRouter_SetsSubjectInContext(t *testing.T) {
 	require.NoError(t, err)
 
 	cases := []struct {
-		name            string
-		claims          jwt.MapClaims
-		expectedSubject string
+		name          string
+		claims        jwt.MapClaims
+		expectSubject bool
+		subject       string
 	}{
 		{
 			name: "sub claim is set in context",
@@ -714,15 +715,25 @@ func TestProxyRouter_SetsSubjectInContext(t *testing.T) {
 				"exp": time.Now().Add(time.Hour).Unix(),
 				"iat": time.Now().Unix(),
 			},
-			expectedSubject: "user-123",
+			expectSubject: true,
+			subject:       "user-123",
 		},
 		{
-			name: "missing sub claim sets null",
+			name: "missing sub claim",
 			claims: jwt.MapClaims{
 				"exp": time.Now().Add(time.Hour).Unix(),
 				"iat": time.Now().Unix(),
 			},
-			expectedSubject: "null",
+			expectSubject: false,
+		},
+		{
+			name: "empty sub claim",
+			claims: jwt.MapClaims{
+				"sub": "",
+				"exp": time.Now().Add(time.Hour).Unix(),
+				"iat": time.Now().Unix(),
+			},
+			expectSubject: false,
 		},
 	}
 
@@ -761,8 +772,10 @@ func TestProxyRouter_SetsSubjectInContext(t *testing.T) {
 			router.ServeHTTP(w, req)
 
 			assert.Equal(t, http.StatusOK, w.Code)
-			assert.True(t, capturedExists)
-			assert.Equal(t, tt.expectedSubject, capturedSubject)
+			assert.Equal(t, tt.expectSubject, capturedExists)
+			if tt.expectSubject {
+				assert.Equal(t, tt.subject, capturedSubject)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

The default ginzap logging is missing any identity information from the auth token.

This adds the "sub" claim as "subject" to the logs.

## Type of Change

- [x] **feat**: A new feature
