### PR TITLE
feat(oidc): outbound PKCE + configurable prompt parameter

### DIFF
--- a/main.go
+++ b/main.go
@@ -156,6 +156,7 @@ type proxyRunnerFunc func(
 	oidcAllowedUsersGlob []string,
 	oidcAllowedAttributes map[string][]string,
 	oidcAllowedAttributesGlob map[string][]string,
+	oidcPrompt string,
 	noProviderAutoSelect bool,
 	password string,
 	passwordHash string,
@@ -208,6 +209,7 @@ func newRootCommand(run proxyRunnerFunc) *cobra.Command {
 	var oidcAllowedUsersGlob string
 	var oidcAllowedAttributes string
 	var oidcAllowedAttributesGlob string
+	var oidcPrompt string
 	var noProviderAutoSelect bool
 	var password string
 	var passwordHash string
@@ -279,6 +281,7 @@ func newRootCommand(run proxyRunnerFunc) *cobra.Command {
 				oidcAllowedUsersGlobList,
 				oidcAllowedAttributesMap,
 				oidcAllowedAttributesGlobMap,
+				oidcPrompt,
 				noProviderAutoSelect,
 				password,
 				passwordHash,
@@ -334,6 +337,7 @@ func newRootCommand(run proxyRunnerFunc) *cobra.Command {
 	rootCmd.Flags().StringVar(&oidcAllowedUsersGlob, "oidc-allowed-users-glob", getEnvWithDefault("OIDC_ALLOWED_USERS_GLOB", ""), "Comma-separated list of glob patterns for allowed OIDC users")
 	rootCmd.Flags().StringVar(&oidcAllowedAttributes, "oidc-allowed-attributes", getEnvWithDefault("OIDC_ALLOWED_ATTRIBUTES", ""), "Comma-separated list of allowed attribute key=value pairs (e.g., /groups=admin,/roles=editor). Keys are JSON pointers.")
 	rootCmd.Flags().StringVar(&oidcAllowedAttributesGlob, "oidc-allowed-attributes-glob", getEnvWithDefault("OIDC_ALLOWED_ATTRIBUTES_GLOB", ""), "Comma-separated list of attribute key=pattern pairs for glob matching (e.g., /groups=*-admins,/email=*@example.com). Keys are JSON pointers.")
+	rootCmd.Flags().StringVar(&oidcPrompt, "oidc-prompt", getEnvWithDefault("OIDC_PROMPT", ""), "Value to send as the OIDC `prompt` parameter on /authorize (e.g. `login` to force re-authentication, `consent` to force consent, `select_account`, `none`). Empty disables.")
 
 	// Password authentication
 	rootCmd.Flags().BoolVar(&noProviderAutoSelect, "no-provider-auto-select", getEnvBoolWithDefault("NO_PROVIDER_AUTO_SELECT", false), "Disable auto-redirect when only one OAuth/OIDC provider is configured and no password is set")

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"sync"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gobwas/glob"
@@ -24,6 +25,12 @@ type oidcProvider struct {
 	allowedUsersGlob      []glob.Glob
 	allowedAttributes     map[string][]string
 	allowedAttributesGlob map[string][]glob.Glob
+	// pkceVerifiers maps the OAuth `state` to its PKCE code_verifier. The
+	// verifier is generated in AuthCodeURL, sent as a code_challenge to the
+	// upstream IdP, and consumed in Exchange to fulfill the PKCE flow.
+	// Required for OAuth 2.1-compliant IdPs (e.g. Duo SSO) that reject
+	// authorization requests without code_challenge.
+	pkceVerifiers sync.Map
 }
 
 func NewOIDCProvider(
@@ -116,7 +123,9 @@ func (p *oidcProvider) AuthURL() string {
 }
 
 func (p *oidcProvider) AuthCodeURL(state string) (string, error) {
-	authURL := p.oauth2.AuthCodeURL(state)
+	verifier := oauth2.GenerateVerifier()
+	p.pkceVerifiers.Store(state, verifier)
+	authURL := p.oauth2.AuthCodeURL(state, oauth2.S256ChallengeOption(verifier))
 	return authURL, nil
 }
 
@@ -125,7 +134,11 @@ func (p *oidcProvider) Exchange(c *gin.Context, state string) (*oauth2.Token, er
 		return nil, errors.New("invalid OAuth state")
 	}
 	code := c.Query("code")
-	token, err := p.oauth2.Exchange(c, code)
+	var opts []oauth2.AuthCodeOption
+	if v, ok := p.pkceVerifiers.LoadAndDelete(state); ok {
+		opts = append(opts, oauth2.VerifierOption(v.(string)))
+	}
+	token, err := p.oauth2.Exchange(c, code, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -25,6 +25,12 @@ type oidcProvider struct {
 	allowedUsersGlob      []glob.Glob
 	allowedAttributes     map[string][]string
 	allowedAttributesGlob map[string][]glob.Glob
+	// promptValue, if non-empty, is sent as the OIDC `prompt` query parameter
+	// on the authorization request. Common values: "login" (force the IdP to
+	// show a login screen even when a valid SSO session exists), "consent",
+	// "select_account", "none". Useful for IdPs (e.g. Entra ID) where silent
+	// SSO would otherwise hide whether MFA was challenged.
+	promptValue string
 	// pkceVerifiers maps the OAuth `state` to its PKCE code_verifier. The
 	// verifier is generated in AuthCodeURL, sent as a code_challenge to the
 	// upstream IdP, and consumed in Exchange to fulfill the PKCE flow.
@@ -37,6 +43,7 @@ func NewOIDCProvider(
 	configurationURL string, scopes []string, userIDField string,
 	providerName, externalURL, clientID, clientSecret string, allowedUsers []string, allowedUsersGlob []string,
 	allowedAttributes map[string][]string, allowedAttributesGlob map[string][]string,
+	promptValue string,
 ) (Provider, error) {
 	resp, err := http.Get(configurationURL)
 	if err != nil {
@@ -103,6 +110,7 @@ func NewOIDCProvider(
 		allowedUsersGlob:      compiledGlobs,
 		allowedAttributes:     allowedAttributes,
 		allowedAttributesGlob: compiledAttributeGlobs,
+		promptValue:           promptValue,
 	}, nil
 }
 
@@ -125,7 +133,11 @@ func (p *oidcProvider) AuthURL() string {
 func (p *oidcProvider) AuthCodeURL(state string) (string, error) {
 	verifier := oauth2.GenerateVerifier()
 	p.pkceVerifiers.Store(state, verifier)
-	authURL := p.oauth2.AuthCodeURL(state, oauth2.S256ChallengeOption(verifier))
+	opts := []oauth2.AuthCodeOption{oauth2.S256ChallengeOption(verifier)}
+	if p.promptValue != "" {
+		opts = append(opts, oauth2.SetAuthURLParam("prompt", p.promptValue))
+	}
+	authURL := p.oauth2.AuthCodeURL(state, opts...)
 	return authURL, nil
 }
 

--- a/pkg/mcp-proxy/main.go
+++ b/pkg/mcp-proxy/main.go
@@ -70,6 +70,7 @@ func Run(
 	oidcAllowedUsersGlob []string,
 	oidcAllowedAttributes map[string][]string,
 	oidcAllowedAttributesGlob map[string][]string,
+	oidcPrompt string,
 	noProviderAutoSelect bool,
 	password string,
 	passwordHash string,
@@ -266,6 +267,7 @@ func Run(
 			oidcAllowedUsersGlob,
 			oidcAllowedAttributes,
 			oidcAllowedAttributesGlob,
+			oidcPrompt,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to create OIDC provider: %w", err)


### PR DESCRIPTION
## Summary

Two related additions to the OIDC client side of the proxy, both surfaced
by trying to use the proxy against IdPs that follow OAuth 2.1 strictly
(in our case Duo SSO and Microsoft Entra ID).

### 1. Outbound PKCE

OAuth 2.1-compliant IdPs reject ``/authorize`` requests that omit
``code_challenge`` + ``code_challenge_method``, even from confidential
clients with a client_secret. Without this patch, configuring such an
IdP fails immediately with errors like:

> ``Must specify both 'code_challenge' and 'code_challenge_method'.``

``AuthCodeURL`` now generates a verifier, stores it keyed by ``state``,
and adds the S256 challenge to the redirect. ``Exchange`` reads the
verifier back via the same ``state`` key and includes it on the token
exchange. Storage is an in-process ``sync.Map`` — acceptable because the
proxy already requires sticky sessions for inbound OAuth state. If
running multi-instance behind a load balancer is on the roadmap, the
verifiers could move into the repository abstraction.

### 2. ``--oidc-prompt`` / ``OIDC_PROMPT``

Sends the value as the OIDC ``prompt`` query parameter on the upstream
``/authorize`` call. Empty (default) preserves current behavior.

Concrete reason this is useful: with Microsoft Entra ID, an existing
browser session silently SSOs through the redirect without ever showing
the IdP's login screen — making it hard to verify operationally whether
MFA actually fires (it did, on the original session, but it's invisible).
``OIDC_PROMPT=login`` forces Entra to render the login page on every
pairing; ``consent`` / ``select_account`` / ``none`` are also accepted
per OIDC Core 1.0 § 3.1.2.1.

## Test plan

- [x] Confirmed against Duo SSO MCP OAuth Server: without the PKCE
      patch, ``/authorize`` returns the "Must specify code_challenge"
      error; with the patch, the flow completes.
- [x] Confirmed against Microsoft Entra ID: without ``OIDC_PROMPT``,
      silent SSO bypasses the login screen; with ``OIDC_PROMPT=login``,
      Entra renders the login page on every pairing.
- [x] No regression on inbound (claude.ai → proxy) flow.
- [ ] No tests touched — let me know if you'd like coverage extending
      ``oidc_test.go`` for the new fields and I'll happily add it.

## Compatibility

- Existing deployments with no ``OIDC_PROMPT`` set: no behavior change.
- Existing deployments against IdPs that don't require PKCE (e.g. Okta,
  Auth0 with default config): no behavior change beyond a (harmless)
  extra ``code_challenge`` on the wire, which they'll accept.

Happy to split this into two PRs if that's preferable — they're
functionally independent. Kept together because they're both very small
and were debugged in the same session.