### PR TITLE
fix: preserve upstream tool schemas verbatim through the stdio→HTTP relay

### DIFF
--- a/pkg/backend/proxy.go
+++ b/pkg/backend/proxy.go
@@ -116,12 +116,17 @@ func setupProxy(ctx context.Context, logger *zap.Logger, tr transport.Bidirectio
 	}
 	s := server.NewMCPServer(init.ServerInfo.Name, init.ServerInfo.Version)
 	if init.Capabilities.Tools != nil {
-		tools, err := c.ListTools(ctx, mcp.ListToolsRequest{})
+		tools, err := listToolsPreservingSchema(ctx, tr)
 		if err != nil {
-			c.Close()
-			return nil, nil, fmt.Errorf("failed to list tools: %w", err)
+			logger.Warn("raw tools/list failed; falling back to typed relay", zap.Error(err))
+			typed, terr := c.ListTools(ctx, mcp.ListToolsRequest{})
+			if terr != nil {
+				c.Close()
+				return nil, nil, fmt.Errorf("failed to list tools: %w", terr)
+			}
+			tools = typed.Tools
 		}
-		for _, tool := range tools.Tools {
+		for _, tool := range tools {
 			s.AddTool(tool, c.CallTool)
 		}
 	}

--- a/pkg/backend/proxy_test.go
+++ b/pkg/backend/proxy_test.go
@@ -2,6 +2,8 @@ package backend
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -58,6 +60,61 @@ func TestSetupProxy(t *testing.T) {
 	require.Equal(t, "1.0", init.ServerInfo.Version)
 }
 
+// failFirstToolsList wraps a BidirectionalInterface and fails the first
+// tools/list request, delegating all other calls. The raw helper issues the
+// first tools/list; the typed fallback issues the second.
+type failFirstToolsList struct {
+	transport.BidirectionalInterface
+	toolsListCount int
+}
+
+func (f *failFirstToolsList) SendRequest(ctx context.Context, req transport.JSONRPCRequest) (*transport.JSONRPCResponse, error) {
+	if req.Method == "tools/list" {
+		f.toolsListCount++
+		if f.toolsListCount == 1 {
+			return nil, fmt.Errorf("simulated raw tools/list failure")
+		}
+	}
+	return f.BidirectionalInterface.SendRequest(ctx, req)
+}
+
+func TestSetupProxyFallsBackOnRawListError(t *testing.T) {
+	logger := zap.NewNop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	s := server.NewMCPServer("test", "1.0")
+	s.AddTool(
+		mcp.NewTool("ping", mcp.WithDescription("ping tool")),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return mcp.NewToolResultText("pong"), nil
+		},
+	)
+	httpServer := server.NewStreamableHTTPServer(
+		s,
+		server.WithEndpointPath("/mcp"),
+		server.WithStateLess(true),
+	)
+
+	testServer := httptest.NewServer(httpServer)
+	defer testServer.Close()
+
+	tr, err := transport.NewStreamableHTTP(testServer.URL + "/mcp")
+	require.NoError(t, err, "failed to create HTTP transport")
+
+	c, handler, err := setupProxy(ctx, logger, &failFirstToolsList{BidirectionalInterface: tr})
+	require.NoError(t, err, "setupProxy should succeed via typed fallback")
+	require.NotNil(t, handler, "handler should not be nil")
+	require.NotNil(t, c, "client should not be nil")
+	defer c.Close()
+
+	proxyServer := httptest.NewServer(handler)
+	defer proxyServer.Close()
+	schemas := rawProxyToolSchemas(t, proxyServer.URL)
+	require.Contains(t, schemas, "ping", "typed fallback should still relay the upstream tool")
+}
+
 func TestProxyBackendRunWithInvalidCommand(t *testing.T) {
 	logger := zap.NewNop()
 	pb := NewProxyBackend(logger, []string{"sh", "-c", "exit 0"})
@@ -106,4 +163,64 @@ func TestProxyBackendRun(t *testing.T) {
 	case <-timeout:
 		t.Error("Test timed out")
 	}
+}
+
+func TestProxyBackendRunPreservesSchema(t *testing.T) {
+	logger := zap.NewNop()
+	pb := NewProxyBackend(logger, []string{"go", "run", "./testserver"})
+	defer pb.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	handler, err := pb.Run(ctx)
+	require.NoError(t, err, "Run should not return error")
+	require.NotNil(t, handler, "handler should not be nil")
+
+	proxyServer := httptest.NewServer(handler)
+	defer proxyServer.Close()
+
+	tr, err := transport.NewStreamableHTTP(proxyServer.URL + "/mcp")
+	require.NoError(t, err, "failed to create proxy transport")
+
+	c := client.NewClient(tr)
+	require.NoError(t, c.Start(ctx), "client should start")
+	defer c.Close()
+	_, err = c.Initialize(ctx, mcp.InitializeRequest{})
+	require.NoError(t, err, "client should initialize")
+
+	resp, err := tr.SendRequest(ctx, transport.JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId("test/tools-list"),
+		Method:  "tools/list",
+	})
+	require.NoError(t, err, "raw tools/list should succeed")
+	require.Nil(t, resp.Error, "raw tools/list should not return an error")
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(resp.Result, &m), "decode tools/list result")
+
+	toolsAny, ok := m["tools"].([]any)
+	require.True(t, ok, "tools/list result should contain a tools array")
+
+	var withDefs map[string]any
+	for _, ta := range toolsAny {
+		tool, ok := ta.(map[string]any)
+		require.True(t, ok, "each tool should be an object")
+		if name, _ := tool["name"].(string); name == "with_defs" {
+			withDefs = tool
+		}
+	}
+	require.NotNil(t, withDefs, "with_defs tool should be relayed")
+
+	input, ok := withDefs["inputSchema"].(map[string]any)
+	require.True(t, ok, "with_defs should have an inputSchema object")
+	require.Contains(t, input, "definitions", "definitions block must be preserved over stdio")
+	require.NotContains(t, input, "$defs", "definitions must not be rewritten to $defs over stdio")
+
+	properties, ok := input["properties"].(map[string]any)
+	require.True(t, ok, "inputSchema should have properties")
+	item, ok := properties["item"].(map[string]any)
+	require.True(t, ok, "properties.item should be an object")
+	require.Equal(t, "#/definitions/Item", item["$ref"], "$ref must still target #/definitions/Item over stdio")
 }

--- a/pkg/backend/testserver/main.go
+++ b/pkg/backend/testserver/main.go
@@ -1,13 +1,34 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"log"
 
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
 
+var rawDraft07Schema = json.RawMessage(`{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"type": "object",
+	"definitions": {
+		"Item": {"type": "string"}
+	},
+	"properties": {
+		"item": {"$ref": "#/definitions/Item"}
+	},
+	"required": ["item"]
+}`)
+
 func main() {
 	s := server.NewMCPServer("test", "1.0")
+	s.AddTool(
+		mcp.NewToolWithRawSchema("with_defs", "stdio fixture", rawDraft07Schema),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return mcp.NewToolResultText(""), nil
+		},
+	)
 	if err := server.ServeStdio(s); err != nil {
 		log.Fatalf("server error: %v", err)
 	}

--- a/pkg/backend/toolschema.go
+++ b/pkg/backend/toolschema.go
@@ -1,0 +1,77 @@
+package backend
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// rawToolsListResult captures each tool's schema exactly as the upstream
+// emitted it, before mcp-go's lossy ToolArgumentsSchema (de)serialization can
+// rewrite "definitions" -> "$defs" or drop unmodeled keywords.
+type rawToolsListResult struct {
+	Tools []struct {
+		InputSchema  json.RawMessage `json:"inputSchema"`
+		OutputSchema json.RawMessage `json:"outputSchema"`
+	} `json:"tools"`
+}
+
+// listToolsPreservingSchema performs a paginated tools/list directly over the
+// transport so the original inputSchema/outputSchema bytes survive verbatim.
+// Tool metadata (name, description, annotations, _meta, ...) still comes from
+// mcp-go's typed parse; only the schemas are carried as Raw*Schema so the proxy
+// server re-emits them unchanged.
+func listToolsPreservingSchema(ctx context.Context, tr transport.Interface) ([]mcp.Tool, error) {
+	var out []mcp.Tool
+	var cursor mcp.Cursor
+	for page := 0; ; page++ {
+		req := mcp.ListToolsRequest{}
+		if cursor != "" {
+			req.Params.Cursor = cursor
+		}
+		resp, err := tr.SendRequest(ctx, transport.JSONRPCRequest{
+			JSONRPC: mcp.JSONRPC_VERSION,
+			ID:      mcp.NewRequestId(fmt.Sprintf("mcp-auth-proxy/tools-list/%d", page)),
+			Method:  "tools/list",
+			Params:  req.Params,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("tools/list request failed: %w", err)
+		}
+		if resp.Error != nil {
+			return nil, fmt.Errorf("tools/list error: %w", resp.Error.AsError())
+		}
+
+		var typed mcp.ListToolsResult
+		if err := json.Unmarshal(resp.Result, &typed); err != nil {
+			return nil, fmt.Errorf("decode tools/list: %w", err)
+		}
+		var raw rawToolsListResult
+		if err := json.Unmarshal(resp.Result, &raw); err != nil {
+			return nil, fmt.Errorf("decode tools/list (raw schemas): %w", err)
+		}
+
+		for i := range typed.Tools {
+			t := typed.Tools[i]
+			if i < len(raw.Tools) {
+				if s := raw.Tools[i].InputSchema; len(s) > 0 {
+					t.RawInputSchema = s
+					t.InputSchema = mcp.ToolInputSchema{}
+				}
+				if s := raw.Tools[i].OutputSchema; len(s) > 0 {
+					t.RawOutputSchema = s
+					t.OutputSchema = mcp.ToolOutputSchema{}
+				}
+			}
+			out = append(out, t)
+		}
+
+		cursor = typed.NextCursor
+		if cursor == "" {
+			return out, nil
+		}
+	}
+}

--- a/pkg/backend/toolschema_test.go
+++ b/pkg/backend/toolschema_test.go
@@ -1,0 +1,349 @@
+package backend
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// Fixture schemas used by the integration tests. They are registered on the
+// upstream via mcp.NewToolWithRawSchema so the upstream serves these exact bytes
+// (registering a typed schema would let the upstream normalize definitions->$defs
+// before the proxy ever sees it, masking the bug under test).
+var (
+	// (a) draft-07 schema with a "definitions" block and a #/definitions/Item $ref.
+	fixtureDefinitionsRef = json.RawMessage(`{
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"type": "object",
+		"definitions": {
+			"Item": {"type": "string"}
+		},
+		"properties": {
+			"item": {"$ref": "#/definitions/Item"}
+		},
+		"required": ["item"]
+	}`)
+
+	// (b) schema carrying root-level $schema, title, and oneOf.
+	fixtureUnmodeledKeywords = json.RawMessage(`{
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title": "ChoiceInput",
+		"type": "object",
+		"properties": {
+			"value": {"type": "string"}
+		},
+		"oneOf": [
+			{"required": ["value"]},
+			{"required": []}
+		]
+	}`)
+
+	// (c) native $defs schema referencing #/$defs/...
+	fixtureNativeDefs = json.RawMessage(`{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"type": "object",
+		"$defs": {
+			"Item": {"type": "string"}
+		},
+		"properties": {
+			"item": {"$ref": "#/$defs/Item"}
+		}
+	}`)
+
+	// (d) plain object schema with no $ref/$defs.
+	fixturePlain = json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"name": {"type": "string"},
+			"count": {"type": "integer"}
+		},
+		"required": ["name"]
+	}`)
+
+	// (e) draft-07 output schema with definitions/$ref.
+	fixtureOutputDefinitionsRef = json.RawMessage(`{
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"type": "object",
+		"definitions": {
+			"Result": {"type": "number"}
+		},
+		"properties": {
+			"result": {"$ref": "#/definitions/Result"}
+		}
+	}`)
+)
+
+// newProxyTestHarness builds an in-process upstream MCP server serving the given
+// tools, runs setupProxy against it, exposes the proxy handler over HTTP, and
+// returns the proxy server's URL. All servers/clients are torn down via t.Cleanup.
+func newProxyTestHarness(t *testing.T, tools ...mcp.Tool) string {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	upstream := server.NewMCPServer("upstream", "1.0")
+	for _, tool := range tools {
+		upstream.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return mcp.NewToolResultText(""), nil
+		})
+	}
+	upstreamServer := httptest.NewServer(server.NewStreamableHTTPServer(
+		upstream,
+		server.WithEndpointPath("/mcp"),
+		server.WithStateLess(true),
+	))
+	t.Cleanup(upstreamServer.Close)
+
+	tr, err := transport.NewStreamableHTTP(upstreamServer.URL + "/mcp")
+	require.NoError(t, err, "failed to create upstream transport")
+
+	c, handler, err := setupProxy(ctx, zap.NewNop(), tr)
+	require.NoError(t, err, "setupProxy should not return error")
+	t.Cleanup(func() { _ = c.Close() })
+
+	proxyServer := httptest.NewServer(handler)
+	t.Cleanup(proxyServer.Close)
+
+	return proxyServer.URL
+}
+
+// rawProxyToolSchemas connects to the proxy and reads the raw tools/list wire
+// bytes (NOT via client.ListTools, which would re-normalize schemas through the
+// lossy ToolArgumentsSchema and mask the proxy's correct output). It returns a
+// map of tool name -> the raw inputSchema/outputSchema objects, keyed "inputSchema"
+// and "outputSchema".
+func rawProxyToolSchemas(t *testing.T, proxyURL string) map[string]map[string]any {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	tr, err := transport.NewStreamableHTTP(proxyURL + "/mcp")
+	require.NoError(t, err, "failed to create proxy transport")
+
+	c := client.NewClient(tr)
+	require.NoError(t, c.Start(ctx), "client should start")
+	t.Cleanup(func() { _ = c.Close() })
+	_, err = c.Initialize(ctx, mcp.InitializeRequest{})
+	require.NoError(t, err, "client should initialize")
+
+	resp, err := tr.SendRequest(ctx, transport.JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId("test/tools-list"),
+		Method:  "tools/list",
+	})
+	require.NoError(t, err, "raw tools/list should succeed")
+	require.Nil(t, resp.Error, "raw tools/list should not return an error")
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(resp.Result, &m), "decode tools/list result")
+
+	toolsAny, ok := m["tools"].([]any)
+	require.True(t, ok, "tools/list result should contain a tools array")
+
+	out := make(map[string]map[string]any)
+	for _, ta := range toolsAny {
+		tool, ok := ta.(map[string]any)
+		require.True(t, ok, "each tool should be an object")
+		name, _ := tool["name"].(string)
+		schemas := make(map[string]any)
+		if input, ok := tool["inputSchema"].(map[string]any); ok {
+			schemas["inputSchema"] = input
+		}
+		if output, ok := tool["outputSchema"].(map[string]any); ok {
+			schemas["outputSchema"] = output
+		}
+		out[name] = schemas
+	}
+	return out
+}
+
+func TestRelayPreservesDefinitionsAndRef(t *testing.T) {
+	tool := mcp.NewToolWithRawSchema("with_defs", "definitions fixture", fixtureDefinitionsRef)
+	proxyURL := newProxyTestHarness(t, tool)
+
+	schemas := rawProxyToolSchemas(t, proxyURL)
+	require.Contains(t, schemas, "with_defs")
+	input, ok := schemas["with_defs"]["inputSchema"].(map[string]any)
+	require.True(t, ok, "with_defs should have an inputSchema object")
+
+	require.Contains(t, input, "definitions", "definitions block must be preserved")
+	require.NotContains(t, input, "$defs", "definitions must not be rewritten to $defs")
+
+	properties, ok := input["properties"].(map[string]any)
+	require.True(t, ok, "inputSchema should have properties")
+	item, ok := properties["item"].(map[string]any)
+	require.True(t, ok, "properties.item should be an object")
+	require.Equal(t, "#/definitions/Item", item["$ref"], "$ref must still target #/definitions/Item")
+}
+
+func TestRelayPreservesUnmodeledKeywords(t *testing.T) {
+	tool := mcp.NewToolWithRawSchema("with_keywords", "unmodeled keywords fixture", fixtureUnmodeledKeywords)
+	proxyURL := newProxyTestHarness(t, tool)
+
+	schemas := rawProxyToolSchemas(t, proxyURL)
+	require.Contains(t, schemas, "with_keywords")
+	input, ok := schemas["with_keywords"]["inputSchema"].(map[string]any)
+	require.True(t, ok, "with_keywords should have an inputSchema object")
+
+	require.Contains(t, input, "$schema", "root-level $schema must be preserved")
+	require.Equal(t, "ChoiceInput", input["title"], "root-level title must be preserved")
+	require.Contains(t, input, "oneOf", "root-level oneOf must be preserved")
+}
+
+func TestRelayPreservesNativeDefs(t *testing.T) {
+	tool := mcp.NewToolWithRawSchema("with_native_defs", "native defs fixture", fixtureNativeDefs)
+	proxyURL := newProxyTestHarness(t, tool)
+
+	schemas := rawProxyToolSchemas(t, proxyURL)
+	require.Contains(t, schemas, "with_native_defs")
+	input, ok := schemas["with_native_defs"]["inputSchema"].(map[string]any)
+	require.True(t, ok, "with_native_defs should have an inputSchema object")
+
+	require.Contains(t, input, "$defs", "$defs block must be preserved")
+	require.NotContains(t, input, "definitions", "native $defs must not become definitions")
+
+	properties, ok := input["properties"].(map[string]any)
+	require.True(t, ok, "inputSchema should have properties")
+	item, ok := properties["item"].(map[string]any)
+	require.True(t, ok, "properties.item should be an object")
+	require.Equal(t, "#/$defs/Item", item["$ref"], "$ref must still target #/$defs/Item")
+}
+
+func TestRelayPlainSchemaUnchanged(t *testing.T) {
+	tool := mcp.NewToolWithRawSchema("with_plain", "plain schema fixture", fixturePlain)
+	proxyURL := newProxyTestHarness(t, tool)
+
+	schemas := rawProxyToolSchemas(t, proxyURL)
+	require.Contains(t, schemas, "with_plain")
+	input, ok := schemas["with_plain"]["inputSchema"].(map[string]any)
+	require.True(t, ok, "with_plain should have an inputSchema object")
+
+	require.Equal(t, "object", input["type"], "type must survive intact")
+
+	properties, ok := input["properties"].(map[string]any)
+	require.True(t, ok, "properties must survive intact")
+	require.Contains(t, properties, "name")
+	require.Contains(t, properties, "count")
+
+	required, ok := input["required"].([]any)
+	require.True(t, ok, "required must survive intact")
+	require.Equal(t, []any{"name"}, required)
+}
+
+func TestRelayPreservesOutputSchema(t *testing.T) {
+	tool := mcp.NewToolWithRawSchema("with_output", "output schema fixture", fixturePlain)
+	tool.RawOutputSchema = fixtureOutputDefinitionsRef
+	proxyURL := newProxyTestHarness(t, tool)
+
+	schemas := rawProxyToolSchemas(t, proxyURL)
+	require.Contains(t, schemas, "with_output")
+	output, ok := schemas["with_output"]["outputSchema"].(map[string]any)
+	require.True(t, ok, "with_output should have an outputSchema object")
+
+	require.Contains(t, output, "definitions", "output definitions block must be preserved")
+	require.NotContains(t, output, "$defs", "output definitions must not be rewritten to $defs")
+
+	properties, ok := output["properties"].(map[string]any)
+	require.True(t, ok, "outputSchema should have properties")
+	result, ok := properties["result"].(map[string]any)
+	require.True(t, ok, "properties.result should be an object")
+	require.Equal(t, "#/definitions/Result", result["$ref"], "$ref must still target #/definitions/Result")
+}
+
+func TestRelayMultipleTools(t *testing.T) {
+	defsTool := mcp.NewToolWithRawSchema("with_defs", "definitions fixture", fixtureDefinitionsRef)
+	nativeTool := mcp.NewToolWithRawSchema("with_native_defs", "native defs fixture", fixtureNativeDefs)
+	proxyURL := newProxyTestHarness(t, defsTool, nativeTool)
+
+	schemas := rawProxyToolSchemas(t, proxyURL)
+	require.Contains(t, schemas, "with_defs")
+	require.Contains(t, schemas, "with_native_defs")
+
+	defsInput, ok := schemas["with_defs"]["inputSchema"].(map[string]any)
+	require.True(t, ok, "with_defs should have an inputSchema object")
+	require.Contains(t, defsInput, "definitions", "with_defs must keep its definitions block")
+	require.NotContains(t, defsInput, "$defs", "with_defs must not pick up $defs from the other tool")
+
+	nativeInput, ok := schemas["with_native_defs"]["inputSchema"].(map[string]any)
+	require.True(t, ok, "with_native_defs should have an inputSchema object")
+	require.Contains(t, nativeInput, "$defs", "with_native_defs must keep its $defs block")
+	require.NotContains(t, nativeInput, "definitions", "with_native_defs must not pick up definitions from the other tool")
+}
+
+// fakeTransport implements transport.Interface, returning canned tools/list
+// responses keyed by the request's pagination cursor.
+type fakeTransport struct {
+	responses map[mcp.Cursor]json.RawMessage
+}
+
+func (f *fakeTransport) Start(ctx context.Context) error { return nil }
+
+func (f *fakeTransport) SendRequest(ctx context.Context, req transport.JSONRPCRequest) (*transport.JSONRPCResponse, error) {
+	var cursor mcp.Cursor
+	if p, ok := req.Params.(mcp.PaginatedParams); ok {
+		cursor = p.Cursor
+	}
+	result, ok := f.responses[cursor]
+	if !ok {
+		return nil, fmt.Errorf("fakeTransport: no canned response for cursor %q", cursor)
+	}
+	return &transport.JSONRPCResponse{Result: result}, nil
+}
+
+func (f *fakeTransport) SendNotification(ctx context.Context, n mcp.JSONRPCNotification) error {
+	return nil
+}
+
+func (f *fakeTransport) SetNotificationHandler(handler func(notification mcp.JSONRPCNotification)) {
+}
+
+func (f *fakeTransport) Close() error { return nil }
+
+func (f *fakeTransport) GetSessionId() string { return "" }
+
+func TestListToolsPreservingSchema_Pagination(t *testing.T) {
+	inputA := json.RawMessage(`{"type":"object","definitions":{"Item":{"type":"string"}},"properties":{"a":{"$ref":"#/definitions/Item"}}}`)
+	inputB := json.RawMessage(`{"type":"object","properties":{"b":{"type":"number"}}}`)
+
+	page0 := json.RawMessage(`{"tools":[{"name":"alpha","description":"first","inputSchema":` + string(inputA) + `}],"nextCursor":"p1"}`)
+	page1 := json.RawMessage(`{"tools":[{"name":"beta","description":"second","inputSchema":` + string(inputB) + `}]}`)
+
+	tr := &fakeTransport{responses: map[mcp.Cursor]json.RawMessage{
+		"":   page0,
+		"p1": page1,
+	}}
+
+	tools, err := listToolsPreservingSchema(context.Background(), tr)
+	require.NoError(t, err)
+	require.Len(t, tools, 2)
+	require.Equal(t, "alpha", tools[0].Name)
+	require.Equal(t, "beta", tools[1].Name)
+	require.JSONEq(t, string(inputA), string(tools[0].RawInputSchema))
+	require.JSONEq(t, string(inputB), string(tools[1].RawInputSchema))
+}
+
+func TestListToolsPreservingSchema_OmittedSchema(t *testing.T) {
+	page0 := json.RawMessage(`{"tools":[{"name":"noschema","description":"no input schema"}]}`)
+
+	tr := &fakeTransport{responses: map[mcp.Cursor]json.RawMessage{
+		"": page0,
+	}}
+
+	tools, err := listToolsPreservingSchema(context.Background(), tr)
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	require.Equal(t, "noschema", tools[0].Name)
+	require.Nil(t, tools[0].RawInputSchema)
+}


### PR DESCRIPTION
## What

When `mcp-auth-proxy` relays `tools/list` from a stdio MCP server over the HTTP `/mcp` endpoint, the tool `inputSchema`/`outputSchema` now reach the downstream client **byte-for-byte identical** to what the upstream emitted.

## Why

The relay round-tripped each schema through mcp-go's typed `ToolArgumentsSchema`, which:

- rewrote JSON-Schema `definitions` → `$defs` **without** rewriting the matching `#/definitions/...` `$ref` targets, producing dangling refs that break JSON-Schema-validating clients (ajv, etc.); and
- silently dropped any root-level keyword it doesn't model (`$schema`, `title`, `oneOf`, …).

Both classes apply to `outputSchema` as well, which uses the same type.

## How

New helper `listToolsPreservingSchema` (`pkg/backend/toolschema.go`) issues `tools/list` directly over the raw transport, parses the **same response bytes twice** (typed `mcp.ListToolsResult` for metadata, a raw struct for the schema bytes), and carries the original schema bytes via `RawInputSchema`/`RawOutputSchema` so the proxy server re-emits them unchanged. `setupProxy` calls it in place of `c.ListTools`, with a graceful fallback to the typed path on error (tool discovery never regresses to unavailable). No `$ref` rewriting or schema normalization is done on our side. Prompts/resources handling and the `NewStreamableHTTPServer` construction are unchanged.

## Testing

- **Unit** (fake transport): pagination, omitted schema, graceful fallback (asserts the tool is still relayed via the fallback).
- **In-process HTTP integration** — reads the proxy's *raw wire bytes* (not a lossy `client.ListTools` round-trip, which would re-normalize and mask the fix): draft-07 `definitions`/`$ref` preserved, unmodeled root keywords preserved, native `$defs` back-compat, plain-schema back-compat, `outputSchema` preserved, and multi-tool index alignment.
- **Real subprocess/stdio integration** test over `go run ./testserver`.
- `gofmt -s`, `go vet`, `go build`, `go test ./...` all green locally. (`staticcheck` runs here in CI — the current release can't analyze go1.26 locally.)

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)
